### PR TITLE
feat(api): add time entry API endpoint

### DIFF
--- a/src/krm3/core/models/auth.py
+++ b/src/krm3/core/models/auth.py
@@ -47,10 +47,16 @@ class User(AbstractUser):
         :return: `True` if the user is allowed to view and edit data on
             any project, `False` otherwise.
         """
-        return (
-            self.is_superuser
-            or self.get_all_permissions().intersection({'core.manage_any_project', 'core.view_any_project'}) != set()
-        )
+        return self.has_any_perm('core.manage_any_project', 'core.view_any_project')
+
+    def has_any_perm(self, *perms: str) -> bool:
+        """Check that the user has at least one of the given permissions.
+
+        :param : the permissions to check
+        :return: `True` if the user has at least one of the given
+          `perms`, `False` otherwise.
+        """
+        return self.is_superuser or any(self.has_perm(perm) for perm in perms)
 
 
 class UserProfile(NaturalKeyModel):

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -133,8 +133,10 @@ class Basket(models.Model):
 
 
 class TaskQuerySet(models.QuerySet['Task']):
-    def active_between(self, start: datetime.date, end: datetime.date) -> Self:
-        return self.filter(start_date__lte=end, end_date__gte=start)
+    def active_between(self, range_start: datetime.date, range_end: datetime.date) -> Self:
+        return self.filter(start_date__lte=range_end).filter(
+            models.Q(end_date=None) | models.Q(end_date__gte=range_start)
+        )
 
     def assigned_to(self, resource: Resource | int) -> Self:
         return self.filter(resource=resource)

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -1,27 +1,28 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, override, Self
-from decimal import Decimal
+from typing import TYPE_CHECKING, Self, override
 
-from django.contrib.auth.models import AbstractUser
-from natural_keys import NaturalKeyModelManager, NaturalKeyModel
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+from natural_keys import NaturalKeyModel, NaturalKeyModelManager
 
 from .auth import Resource
 from .contacts import Client
 from .timesheets import TimeEntry
 
 if TYPE_CHECKING:
-    from .auth import User
+    from decimal import Decimal
+
+    from django.contrib.auth.models import AbstractUser
     from django.db.models.fields.related_descriptors import RelatedManager
+
     from .accounting import InvoiceEntry
+    from .auth import User
     from .missions import Mission
 
 
 _DEFAULT_START_DATE = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
-
 
 
 class ProjectManager(NaturalKeyModelManager):
@@ -60,7 +61,6 @@ class Project(NaturalKeyModel):
             ('view_any_project', "Can view(only) everybody's projects"),
             ('manage_any_project', "Can view, and manage everybody's projects"),
         ]
-
 
 
 class POState(models.TextChoices):
@@ -132,7 +132,7 @@ class Basket(models.Model):
         return self.current_capacity() - logged_hours
 
 
-class TaskQuerySet(models.QuerySet[type['Task']]):
+class TaskQuerySet(models.QuerySet['Task']):
     def active_between(self, start: datetime.date, end: datetime.date) -> Self:
         return self.filter(start_date__lte=end, end_date__gte=start)
 

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -180,4 +180,10 @@ class Task(models.Model):
         return self.title
 
     def time_entries_between(self, start: datetime.date, end: datetime.date) -> models.QuerySet[TimeEntry]:
+        """Return all time entries between the two given dates.
+
+        :param start: the date at the start of the range
+        :param end: the date at the end of the range
+        :return: a `QuerySet` of time entries
+        """
         return self.time_entries.filter(date__range=(start, end))

--- a/src/krm3/core/models/timesheets.py
+++ b/src/krm3/core/models/timesheets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import TYPE_CHECKING, override, Self, Any
 
 from django.core.exceptions import ValidationError
@@ -11,6 +10,7 @@ from django.dispatch import receiver
 from .auth import Resource
 
 if TYPE_CHECKING:
+    from decimal import Decimal
     from django.contrib.auth.models import AbstractUser
 
 
@@ -28,6 +28,7 @@ class TimeEntryQuerySet(models.QuerySet['TimeEntry']):
         :return: the filtered queryset.
         """
         from .projects import POState
+
         return self.filter(state=POState.OPEN)
 
     def filter_acl(self, user: AbstractUser) -> Self:
@@ -60,7 +61,7 @@ class TimeEntry(models.Model):
     metadata = models.JSONField(default=dict, null=True, blank=True)
 
     resource = models.ForeignKey(Resource, on_delete=models.CASCADE)
-    task = models.ForeignKey("Task", on_delete=models.CASCADE, related_name='time_entries')
+    task = models.ForeignKey('Task', on_delete=models.CASCADE, related_name='time_entries')
 
     objects = TimeEntryQuerySet.as_manager()
 

--- a/src/krm3/core/models/timesheets.py
+++ b/src/krm3/core/models/timesheets.py
@@ -113,7 +113,8 @@ class TimeEntry(models.Model):
         is_holiday = self.holiday_hours > 0.0
         is_leave = self.leave_hours > 0.0
 
-        if is_sick_day and is_holiday and is_leave:
+        has_too_many_absences_logged = len([cond for cond in (is_sick_day, is_holiday, is_leave) if cond]) > 1
+        if has_too_many_absences_logged:
             errors.append(
                 ValidationError(
                     _('You cannot log more than one kind of absence in a day.'),

--- a/src/krm3/core/models/timesheets.py
+++ b/src/krm3/core/models/timesheets.py
@@ -82,7 +82,17 @@ class TimeEntry(models.Model):
 
         :return: the computed total.
         """
-        return self.work_hours + self.leave_hours + self.overtime_hours + self.travel_hours + self.rest_hours
+        return self.work_hours + self.overtime_hours + self.travel_hours + self.rest_hours
+
+    @property
+    def total_hours(self) -> Decimal:
+        """Compute the grand total of all hours logged on this entry.
+
+        This includes hours logged as absence.
+
+        :return: the computed total.
+        """
+        return self.total_work_hours + self.leave_hours + self.sick_hours + self.holiday_hours
 
     @override
     def clean(self) -> None:

--- a/src/krm3/timesheet/api/serializers.py
+++ b/src/krm3/timesheet/api/serializers.py
@@ -5,11 +5,15 @@ from rest_framework import serializers
 from krm3.core.models import Task, TimeEntry
 
 
-class TimeEntrySerializer(serializers.ModelSerializer):
-    last_modified = serializers.SerializerMethodField()
-
+class BaseTimeEntrySerializer(serializers.ModelSerializer):
     class Meta:
         model = TimeEntry
+
+
+class TimeEntryReadSerializer(BaseTimeEntrySerializer):
+    last_modified = serializers.SerializerMethodField()
+
+    class Meta(BaseTimeEntrySerializer.Meta):
         fields = (
             'id',
             'date',
@@ -25,9 +29,28 @@ class TimeEntrySerializer(serializers.ModelSerializer):
             'state',
             'comment',
         )
+        read_only_fields = fields
 
     def get_last_modified(self, obj: TimeEntry) -> str:
         return obj.last_modified.isoformat()
+
+
+class TimeEntryCreateSerializer(BaseTimeEntrySerializer):
+    class Meta(BaseTimeEntrySerializer.Meta):
+        fields = (
+            'date',
+            'work_hours',
+            'sick_hours',
+            'holiday_hours',
+            'leave_hours',
+            'overtime_hours',
+            'on_call_hours',
+            'travel_hours',
+            'rest_hours',
+            'comment',
+            'task',
+            'resource',
+        )
 
 
 class TaskSerializer(serializers.ModelSerializer):
@@ -64,4 +87,4 @@ class TimesheetTaskSerializer(TaskSerializer):
         time_entries = obj.time_entries.all()
         if self._start_date and self._end_date:
             time_entries = obj.time_entries_between(self._start_date, self._end_date)
-        return TimeEntrySerializer(time_entries, many=True).data
+        return TimeEntryReadSerializer(time_entries, many=True).data

--- a/src/krm3/timesheet/api/urls.py
+++ b/src/krm3/timesheet/api/urls.py
@@ -5,5 +5,6 @@ from krm3.timesheet.api import views as api_views
 router = routers.SimpleRouter()
 
 router.register('task', api_views.TaskAPIViewSet, basename='api-task')
+router.register('time-entry', api_views.TimeEntryAPIViewSet, basename='api-time-entry')
 
 urlpatterns = router.urls

--- a/src/krm3/timesheet/api/views.py
+++ b/src/krm3/timesheet/api/views.py
@@ -21,13 +21,9 @@ class TaskAPIViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     def get_queryset(self) -> QuerySet[Task]:
         user = cast('User', self.request.user)
 
-        # privileged users can view everyone's tasks
         if user.can_manage_and_view_any_project():
             return Task.objects.all()
-
-        # regular users can only view their own tasks
-        resource = Resource.objects.get(user=user)
-        return Task.objects.assigned_to(resource=resource)  # pyright: ignore
+        return Task.objects.filter_acl(user=user)  # pyright: ignore
 
     @override
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/src/krm3/timesheet/api/views.py
+++ b/src/krm3/timesheet/api/views.py
@@ -31,8 +31,8 @@ class TaskAPIViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             resource_id = request.query_params['resource_id']
             start_date_iso = request.query_params['start_date']
             end_date_iso = request.query_params['end_date']
-        except KeyError as e:
-            return Response(data={'error': f'Missing mandatory field {e}.'}, status=status.HTTP_400_BAD_REQUEST)
+        except KeyError:
+            return Response(data={'error': 'Required query parameter(s) missing.'}, status=status.HTTP_400_BAD_REQUEST)
 
         resource = Resource.objects.get(pk=resource_id)
         if resource.user != request.user and not cast('User', request.user).can_manage_and_view_any_project():
@@ -40,17 +40,13 @@ class TaskAPIViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
         try:
             start_date = datetime.date.fromisoformat(start_date_iso)
-        except (TypeError, ValueError) as e:
-            return Response(
-                data={'error': 'Cannot parse start date.', 'reason': str(e)}, status=status.HTTP_400_BAD_REQUEST
-            )
+        except (TypeError, ValueError):
+            return Response(data={'error': 'Cannot parse start date.'}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
             end_date = datetime.date.fromisoformat(end_date_iso)
-        except (TypeError, ValueError) as e:
-            return Response(
-                data={'error': 'Cannot parse end date.', 'reason': str(e)}, status=status.HTTP_400_BAD_REQUEST
-            )
+        except (TypeError, ValueError):
+            return Response(data={'error': 'Cannot parse end date.'}, status=status.HTTP_400_BAD_REQUEST)
 
         if start_date > end_date:
             return Response(

--- a/src/krm3/timesheet/api/views.py
+++ b/src/krm3/timesheet/api/views.py
@@ -1,13 +1,20 @@
 import datetime
 from typing import TYPE_CHECKING, Any, cast, override
 
+from django.db import transaction
 from django.db.models import QuerySet
 from rest_framework import mixins, permissions, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from krm3.core.models import Resource, Task
-from krm3.timesheet.api.serializers import TimesheetTaskSerializer
+from krm3.core.models.timesheets import TimeEntry
+from krm3.timesheet.api.serializers import (
+    BaseTimeEntrySerializer,
+    TimeEntryReadSerializer,
+    TimeEntryCreateSerializer,
+    TimesheetTaskSerializer,
+)
 
 if TYPE_CHECKING:
     from krm3.core.models import User
@@ -56,3 +63,49 @@ class TaskAPIViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         tasks = self.get_queryset().active_between(start_date, end_date).assigned_to(resource=resource_id)  # pyright: ignore
         task_data = self.get_serializer(tasks, many=True, start_date=start_date, end_date=end_date).data
         return Response(task_data)
+
+
+class TimeEntryAPIViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @override
+    def get_queryset(self) -> QuerySet[TimeEntry]:
+        user = cast('User', self.request.user)
+        if user.has_any_perm('core.manage_any_timesheet', 'core.view_any_timesheet'):
+            return TimeEntry.objects.all()
+        return TimeEntry.objects.filter_acl(user=user)  # pyright: ignore
+
+    @override
+    def get_serializer_class(self) -> type[BaseTimeEntrySerializer]:
+        if self.request.method == 'POST':
+            return TimeEntryCreateSerializer
+        return TimeEntryReadSerializer
+
+    @override
+    def create(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        try:
+            dates = request.data.pop('dates')
+        except KeyError:
+            return Response(data={'error': 'Provide at least one date.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not isinstance(dates, list):
+            return Response(
+                data={'error': 'List of dates required, but got single date'}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            request.data['task'] = request.data.pop('task_id')
+            request.data['resource'] = request.data.pop('resource_id')
+        except KeyError:
+            return Response(data={'error': 'Provide both task and resource ID.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        with transaction.atomic():
+            for date in dates:
+                time_entry_data = request.data.copy()
+                time_entry_data.setdefault('date', date)
+                serializer = self.get_serializer(data=time_entry_data, context={'request': request})
+                if serializer.is_valid(raise_exception=True):
+                    self.perform_create(serializer)
+
+        headers = self.get_success_headers(serializer.data)
+        return Response(status=status.HTTP_201_CREATED, headers=headers)

--- a/tests/unit/timesheet/api/test_task_viewset.py
+++ b/tests/unit/timesheet/api/test_task_viewset.py
@@ -28,21 +28,22 @@ class TestTaskAPIListView:
     def test_rejects_missing_query_params(self, admin_user, api_client):
         client = api_client(user=admin_user)
         params = {}
+        expected_error_payload = {'error': 'Required query parameter(s) missing.'}
 
         response = client.get(self.url(), data=params)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data == {'error': "Missing mandatory field 'resource_id'."}
+        assert response.data == expected_error_payload
 
         resource = ResourceFactory()
         params.setdefault('resource_id', resource.pk)
         response = client.get(self.url(), data=params)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data == {'error': "Missing mandatory field 'start_date'."}
+        assert response.data == expected_error_payload
 
         params.setdefault('start_date', '2024-01-01')
         response = client.get(self.url(), data=params)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data == {'error': "Missing mandatory field 'end_date'."}
+        assert response.data == expected_error_payload
 
         params.setdefault('end_date', '2024-01-07')
         response = client.get(self.url(), data=params)
@@ -64,10 +65,7 @@ class TestTaskAPIListView:
         response = api_client(user=admin_user).get(self.url(), data=params)
         assert response.status_code == expected_status_code
         if expected_status_code >= 400:
-            assert response.data == {
-                'error': 'Cannot parse start date.',
-                'reason': f"Invalid isoformat string: '{str(start_date)}'",
-            }
+            assert response.data == {'error': 'Cannot parse start date.'}
 
     @pytest.mark.parametrize(('end_date', 'expected_status_code'), _iso_date_test_cases)
     def test_rejects_non_iso_end_date(self, end_date, expected_status_code, admin_user, api_client):
@@ -76,10 +74,7 @@ class TestTaskAPIListView:
         response = api_client(user=admin_user).get(self.url(), data=params)
         assert response.status_code == expected_status_code
         if expected_status_code >= 400:
-            assert response.data == {
-                'error': 'Cannot parse end date.',
-                'reason': f"Invalid isoformat string: '{str(end_date)}'",
-            }
+            assert response.data == {'error': 'Cannot parse end date.'}
 
     @pytest.mark.parametrize(
         ('end_date', 'expected_status_code'),

--- a/tests/unit/timesheet/api/test_task_viewset.py
+++ b/tests/unit/timesheet/api/test_task_viewset.py
@@ -93,7 +93,6 @@ class TestTaskAPIListView:
             pytest.param('2023-12-26', status.HTTP_400_BAD_REQUEST, id='end_date_earlier_than_start_date'),
             pytest.param('2024-01-01', status.HTTP_200_OK, id='end_date_same_as_start_date'),
             pytest.param('2024-01-07', status.HTTP_200_OK, id='end_date_later_than_start_date'),
-            pytest.param(None, status.HTTP_200_OK, id='open_ended'),
         ],
     )
     def test_validates_date_range(self, end_date, expected_status_code, admin_user, api_client):
@@ -150,7 +149,7 @@ class TestTaskAPIListView:
             'basketTitle': task.basket_title,
             'color': task.color,
             'startDate': task_start_date.isoformat(),
-            'endDate': task_end_date.isoformat(),
+            'endDate': task_end_date.isoformat() if task_end_date else None,
             'projectName': task.project.name,
             'timeEntries': [
                 {


### PR DESCRIPTION
This PR adds the `/api/v1/timesheet/time-entry/` endpoint.

The endpoint accepts only POST calls for now.