### PR TITLE
feat(api): add custom POST endpoint for time entry bulk deletion

### DIFF
--- a/src/krm3/core/models/timesheets.py
+++ b/src/krm3/core/models/timesheets.py
@@ -31,6 +31,15 @@ class TimeEntryQuerySet(models.QuerySet['TimeEntry']):
 
         return self.filter(state=POState.OPEN)
 
+    def closed(self) -> Self:
+        """Select the closed time entries in this queryset.
+
+        :return: the filtered queryset.
+        """
+        from .projects import POState
+
+        return self.filter(state=POState.CLOSED)
+
     def filter_acl(self, user: AbstractUser) -> Self:
         """Return the queryset for the owned records.
 


### PR DESCRIPTION
This PR adds a POST endpoint for bulk deletion of time entries.

A possible frequent use case for this endpoint is clearing existing all entries in a day to replace them with a new day entry.