### PR TITLE
fix: Overwrite time entries on same task and/or day

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,4 +79,5 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.pyright]
+extraPaths = ["tests/_extras"]
 typeCheckingMode="basic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,6 @@ image = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.pyright]
+typeCheckingMode="basic"

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Self, override
 
-from django.contrib.auth import get_user_model
+# from django.contrib.auth import get_user_model  # noqa - see below
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from natural_keys import NaturalKeyModel, NaturalKeyModelManager
@@ -14,6 +14,7 @@ from .timesheets import TimeEntry
 
 if TYPE_CHECKING:
     from decimal import Decimal
+    from krm3.core.models.auth import User
     from krm3.core.models import Project, Task, Mission, InvoiceEntry
 
     from django.contrib.auth.models import AbstractUser
@@ -22,7 +23,8 @@ if TYPE_CHECKING:
 
 _DEFAULT_START_DATE = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
 
-User = get_user_model()
+# FIXME: we cannot use a variable as a type hint
+# User = get_user_model()  # noqa
 
 
 class ProjectManager(NaturalKeyModelManager):
@@ -73,7 +75,7 @@ class PO(models.Model):
 
     ref = models.CharField(max_length=50)
     is_billable = models.BooleanField(default=True)
-    state = models.TextField(choices=POState, default=POState.OPEN)  # type: ignore
+    state = models.TextField(choices=POState, default=POState.OPEN)  # pyright: ignore[reportArgumentType]
     start_date = models.DateField(default=_DEFAULT_START_DATE)
     end_date = models.DateField(null=True, blank=True)
 

--- a/src/krm3/core/models/timesheets.py
+++ b/src/krm3/core/models/timesheets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, override, Self, Any
+from typing import TYPE_CHECKING, cast, override, Self, Any
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -22,6 +22,15 @@ class TimeEntryState(models.TextChoices):
 
 
 class TimeEntryQuerySet(models.QuerySet['TimeEntry']):
+    _TASK_ENTRY_FILTER = (
+        models.Q(work_hours__gt=0)
+        | models.Q(travel_hours__gt=0)
+        | models.Q(rest_hours__gt=0)
+        | models.Q(overtime_hours__gt=0)
+    )
+
+    _DAY_ENTRY_FILTER = models.Q(sick_hours__gt=0) | models.Q(holiday_hours__gt=0) | models.Q(leave_hours__gt=0)
+
     def open(self) -> Self:
         """Select the open time entries in this queryset.
 
@@ -39,6 +48,27 @@ class TimeEntryQuerySet(models.QuerySet['TimeEntry']):
         from .projects import POState
 
         return self.filter(state=POState.CLOSED)
+
+    def day_entries(self) -> Self:
+        """Select all day entries in this queryset.
+
+        :return: the filtered queryset.
+        """
+        return self.filter(self._DAY_ENTRY_FILTER & ~self._TASK_ENTRY_FILTER)
+
+    def sick_days_and_holidays(self) -> Self:
+        """Select all sick and holiday entries in this queryset.
+
+        :return: the filtered queryset.
+        """
+        return self.day_entries().filter(leave_hours=0)
+
+    def task_entries(self) -> Self:
+        """Select all task entries in this queryset.
+
+        :return: the filtered queryset.
+        """
+        return self.filter(self._TASK_ENTRY_FILTER & ~self._DAY_ENTRY_FILTER)
 
     def filter_acl(self, user: AbstractUser) -> Self:
         """Return the queryset for the owned records.
@@ -135,40 +165,21 @@ class TimeEntry(models.Model):
           is violated.
         """
         errors = []
-        other_entries_on_same_day = TimeEntry.objects.filter(date=self.date, resource=self.resource).exclude(pk=self.pk)  # pyright: ignore[reportAttributeAccessIssue]
 
         has_task_entry_hours = self.total_task_hours > 0.0 or self.on_call_hours > 0.0
-        if self.is_day_entry:
-            other_day_entries = other_entries_on_same_day.filter(task__isnull=True)
-            if other_day_entries.exists():
-                message = _(
-                    'Date {date} already has a day entry. Consider deleting it before trying again.'.format(
-                        date=self.date
-                    )
-                )
-                errors.append(ValidationError(message, code='multiple_day_entries'))
-            if has_task_entry_hours:
-                errors.append(
-                    ValidationError(_('You cannot log task hours in a day entry.'), code='task_hours_in_day_entry')
-                )
+        if self.is_day_entry and has_task_entry_hours:
+            errors.append(
+                ValidationError(_('You cannot log task hours in a day entry.'), code='task_hours_in_day_entry')
+            )
 
         is_sick_day = self.sick_hours > 0.0
         is_holiday = self.holiday_hours > 0.0
         is_leave = self.leave_hours > 0.0
         has_day_entry_hours = is_sick_day or is_holiday or is_leave
-        if self.is_task_entry:
-            other_task_entries = other_entries_on_same_day.filter(task=self.task)
-            if other_task_entries.exists():
-                message = _(
-                    'Task {task} already has a time entry on {date}. Consider deleting it before trying again.'.format(
-                        task=self.task, date=self.date
-                    )
-                )
-                errors.append(ValidationError(message, code='multiple_task_entries'))
-            if has_day_entry_hours:
-                errors.append(
-                    ValidationError(_('You cannot log an absence in a task entry.'), code='day_hours_in_task_entry')
-                )
+        if self.is_task_entry and has_day_entry_hours:
+            errors.append(
+                ValidationError(_('You cannot log an absence in a task entry.'), code='day_hours_in_task_entry')
+            )
 
         has_too_many_absences_logged = len([cond for cond in (is_sick_day, is_holiday, is_leave) if cond]) > 1
         if has_too_many_absences_logged:
@@ -191,3 +202,27 @@ class TimeEntry(models.Model):
 @receiver(models.signals.pre_save, sender=TimeEntry)
 def validate_time_entry(sender: TimeEntry, instance: TimeEntry, **kwargs: Any) -> None:
     instance.clean()
+
+
+@receiver(models.signals.post_save, sender=TimeEntry)
+def clear_sick_day_or_holiday_entry_on_same_day(sender: TimeEntry, instance: TimeEntry, **kwargs: Any) -> None:
+    if instance.is_task_entry:
+        overwritten = (
+            cast('TimeEntryQuerySet', TimeEntry.objects)
+            .open()
+            .sick_days_and_holidays()
+            .filter(date=instance.date, resource=instance.resource)
+        )
+        overwritten.delete()
+
+
+@receiver(models.signals.post_save, sender=TimeEntry)
+def clear_task_entries_on_same_day(sender: TimeEntry, instance: TimeEntry, **kwargs: Any) -> None:
+    if instance.is_day_entry and instance.leave_hours == 0:
+        overwritten = (
+            cast('TimeEntryQuerySet', TimeEntry.objects)
+            .open()
+            .task_entries()
+            .filter(date=instance.date, resource=instance.resource)
+        )
+        overwritten.delete()

--- a/src/krm3/timesheet/api/serializers.py
+++ b/src/krm3/timesheet/api/serializers.py
@@ -111,6 +111,16 @@ class TimeEntryCreateSerializer(BaseTimeEntrySerializer):
             )
         return value
 
+    @override
+    def create(self, validated_data: Any) -> TimeEntry:
+        date = validated_data.pop('date')
+        resource = validated_data.pop('resource')
+        task = validated_data.pop('task', None)
+        entry, _created = TimeEntry.objects.update_or_create(
+            date=date, resource=resource, task=task, defaults=validated_data
+        )
+        return entry
+
 
 class TaskSerializer(serializers.ModelSerializer):
     class Meta:

--- a/uv.lock
+++ b/uv.lock
@@ -945,7 +945,7 @@ wheels = [
 
 [[package]]
 name = "krm3"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Time entries are now overwritten if another time entry is requested to be saved in the same day/task.

Saving a task entry for a given resource now clears any existing sick day or holiday entry on the same day for that resource (leave entries can coexist with task entries, though).

Saving a day entry for a given resource now clears all task entries on the same day for that resource.