### PR TITLE
test: mark UI tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,10 @@ env_files =
     .test.env
 testpaths=tests
 addopts =
+    -m "not ui"
     --reuse-db
     --cov-report=html
     --cov-config=tests/.coveragerc
     --cov=krm3
+markers =
+    ui: integration tests using Selenium

--- a/tests/integration/test_fe_login.py
+++ b/tests/integration/test_fe_login.py
@@ -5,9 +5,11 @@ import typing
 if typing.TYPE_CHECKING:
     from testutils.selenium import AppTestBrowser
 
+pytestmark = pytest.mark.ui
+
 
 @pytest.mark.django_db
-def test_login_ok(browser: "AppTestBrowser", regular_user):
+def test_login_ok(browser: 'AppTestBrowser', regular_user):
     browser.open('/')
     browser.type('#username', regular_user.username)
     browser.type('#password', 'password')
@@ -16,7 +18,7 @@ def test_login_ok(browser: "AppTestBrowser", regular_user):
 
 
 @pytest.mark.django_db
-def test_login_nok(browser: "AppTestBrowser", regular_user):
+def test_login_nok(browser: 'AppTestBrowser', regular_user):
     browser.open('/')
     browser.type('#username', regular_user.username)
     browser.type('#password', 'wrong')


### PR DESCRIPTION
This patch creates a `ui` mark for Selenium tests and adds an exclusion rule in `pytest.ini` so that they are not selected when running the test suite with the `pytest` command.

Tests marked as `ui` can still be run using the command `pytest -m ui`.