### PR TITLE
Validate leave hours

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,10 +5,10 @@ env_files =
     .test.env
 testpaths=tests
 addopts =
-    -m "not ui"
+    -m "not selenium"
     --reuse-db
     --cov-report=html
     --cov-config=tests/.coveragerc
     --cov=krm3
 markers =
-    ui: integration tests using Selenium
+    selenium: integration tests using Selenium

--- a/src/krm3/core/models/auth.py
+++ b/src/krm3/core/models/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 import typing
 from django.contrib.auth.base_user import BaseUserManager
 from natural_keys import NaturalKeyModel
@@ -88,6 +89,16 @@ class Resource(models.Model):
 
     def __str__(self) -> str:
         return f'{self.first_name} {self.last_name}'
+
+    @property
+    def daily_work_hours_max(self) -> Decimal:
+        """Maximum number of hours a resource should work each day.
+
+        It can be exceeded.
+
+        :return: the maximum number of hours in a work day.
+        """
+        return Decimal(8)
 
 
 @receiver(post_save, sender=User)

--- a/tests/integration/test_fe_login.py
+++ b/tests/integration/test_fe_login.py
@@ -5,7 +5,7 @@ import typing
 if typing.TYPE_CHECKING:
     from testutils.selenium import AppTestBrowser
 
-pytestmark = pytest.mark.ui
+pytestmark = pytest.mark.selenium
 
 
 @pytest.mark.django_db

--- a/tests/unit/timesheet/api/test_task_viewset.py
+++ b/tests/unit/timesheet/api/test_task_viewset.py
@@ -128,7 +128,7 @@ class TestTaskAPIListView:
 
         _early_time_entry = _make_time_entry(date=datetime.date(2023, 7, 1), comment='Too early')
         _late_time_entry = _make_time_entry(date=datetime.date(2024, 7, 1), comment='Too late')
-        task_entry_within_range = _make_time_entry(date=date_within_range, comment='Within range')
+        task_entry_within_range = _make_time_entry(date=date_within_range, day_shift_hours=6, comment='Within range')
         day_entry_within_range = _make_time_entry(
             date=date_within_range, task=None, day_shift_hours=0, leave_hours=2, comment='Within range (day)'
         )
@@ -564,13 +564,14 @@ class TestTimeEntryAPICreateView:
         task = TaskFactory(resource=resource)
 
         # we made a mistake and inadvertently saved 18 hours... oops :^)
-        _wrong_day_entry = TimeEntryFactory(resource=resource, task=None, date=today, day_shift_hours=0, leave_hours=18)
-        _task_entry = TimeEntryFactory(resource=resource, task=task, date=today, day_shift_hours=2)
+        # NOTE: this should only be possible when tampering with the
+        # admin panel
+        _wrong_day_entry = TimeEntryFactory(resource=resource, task=None, date=today, day_shift_hours=0, sick_hours=18)
 
         # let's correct it
         response = api_client(user=admin_user).post(
             self.url(),
-            data={'dates': [today.isoformat()], 'resourceId': resource.id, 'dayShiftHours': 0, hours_key: 6},
+            data={'dates': [today.isoformat()], 'resourceId': resource.id, 'dayShiftHours': 0, hours_key: 8},
             format='json',
         )
         assert response.status_code == status.HTTP_201_CREATED
@@ -724,7 +725,7 @@ class TestTimeEntryAPICreateView:
             'resourceId': resource.pk,
             'comment': 'approved',
             'dayShiftHours': 0,
-        } | {hours_key: 8}
+        } | {hours_key: 4 if hours_key.startswith('leave') else 8}
 
         response = api_client(user=admin_user).post(self.url(), data=data, format='json')
         assert response.status_code == status.HTTP_201_CREATED

--- a/tests/unit/timesheet/test_time_entry_model.py
+++ b/tests/unit/timesheet/test_time_entry_model.py
@@ -117,7 +117,7 @@ class TestTimeEntry:
         resource = ResourceFactory()
         absence_day = datetime.date(2024, 1, 1)
         _absence_entry = TimeEntryFactory(
-            date=absence_day, day_shift_hours=0, **{existing_hours_field: 8}, resource=resource
+            date=absence_day, day_shift_hours=0, resource=resource, **{existing_hours_field: 8}
         )
         assert TimeEntry.objects.day_entries().filter(date=absence_day, resource=resource).count() == 1  # pyright: ignore
 
@@ -125,7 +125,7 @@ class TestTimeEntry:
             # the same resource should be able to log their absence on
             # a different available day
             _absence_entry_on_other_day = TimeEntryFactory(
-                date=datetime.date(2024, 1, 2), day_shift_hours=0, **{new_hours_field: 8}, resource=resource
+                date=datetime.date(2024, 1, 2), day_shift_hours=0, resource=resource, **{new_hours_field: 8}
             )
 
             # another resource should be able to log their own absence
@@ -135,7 +135,7 @@ class TestTimeEntry:
                 date=absence_day, day_shift_hours=0, **{new_hours_field: 8}, resource=other_resource
             )
 
-        _new_entry = TimeEntryFactory(date=absence_day, day_shift_hours=0, **{new_hours_field: 8}, resource=resource)
+        _new_entry = TimeEntryFactory(date=absence_day, day_shift_hours=0, resource=resource, **{new_hours_field: 8})
         day_entries = TimeEntry.objects.day_entries().filter(date=absence_day, resource=resource)  # pyright: ignore
         assert day_entries.count() == 1
         assert getattr(day_entries.get(), new_hours_field) == 8
@@ -201,7 +201,7 @@ class TestTimeEntry:
         assert entry.holiday_hours == 8
 
     def test_is_saved_as_leave(self):
-        """Sick day with no work or task-related hours logged"""
+        """Leave hours with no work or task-related hours logged"""
         entry = TimeEntryFactory(day_shift_hours=8, task=TaskFactory())
         entry.day_shift_hours = 0
         entry.leave_hours = 8


### PR DESCRIPTION
This adds validation criteria for leave hours in order to prevent users from logging overtime hours on days with a leave.