### PR TITLE
fix(core): validate start and end dates in models with date ranges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ dev = [
     "django-tailwind[reload]>=4.0.1",
     "django-webtest>=1.9.13",
     "djangorestframework-stubs>=3.15.3",
+    "freezegun>=1.5.2",
     "opencv-python>=4.11.0.86",
     "pdbpp>=0.10.3",
     "pre-commit>=4.2.0",

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -103,6 +103,26 @@ class PO(models.Model):
     def __str__(self) -> str:
         return self.ref
 
+    @override
+    def save(
+        self,
+        *,
+        force_insert: bool | tuple[ModelBase, ...] = False,
+        force_update: bool = False,
+        using: str | None = None,
+        update_fields: Iterable[str] | None = None,
+    ) -> None:
+        self.full_clean()
+        return super().save(
+            force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields
+        )
+
+    @override
+    def clean(self) -> None:
+        if self.end_date and self.start_date > self.end_date:
+            raise ValidationError(_('"start_date" must not be later than "end_date"'), code='invalid_date_interval')
+        return super().clean()
+
 
 class Basket(models.Model):
     """Defines the cumulative availability of person-hours for a PO."""

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -231,7 +231,10 @@ class Task(models.Model):
 
     @override
     def clean(self) -> None:
-        if self.start_date and self.project.start_date and self.start_date < self.project.start_date:
+        if self.end_date and self.start_date > self.end_date:
+            raise ValidationError(_('"start_date" must not be later than "end_date"'), code='invalid_date_interval')
+
+        if self.project.start_date and self.start_date < self.project.start_date:
             raise ValidationError(
                 _(
                     'A task must not start before its related project - '

--- a/src/krm3/core/models/timesheets.py
+++ b/src/krm3/core/models/timesheets.py
@@ -54,6 +54,26 @@ class SpecialLeaveReason(models.Model):
             interval = ''
         return f'{self.title}{interval}'
 
+    @override
+    def save(
+        self,
+        *,
+        force_insert: bool | tuple[ModelBase, ...] = False,
+        force_update: bool = False,
+        using: str | None = None,
+        update_fields: Iterable[str] | None = None,
+    ) -> None:
+        self.full_clean()
+        return super().save(
+            force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields
+        )
+
+    @override
+    def clean(self) -> None:
+        if self.from_date and self.to_date and self.from_date > self.to_date:
+            raise ValidationError(_('"from_date" must not be later than "to_date"'), code='invalid_date_interval')
+        return super().clean()
+
     def is_not_valid_yet(self, date: datetime.date) -> bool:
         return self.from_date is not None and date < self.from_date
 

--- a/tests/unit/projects/test_project_models.py
+++ b/tests/unit/projects/test_project_models.py
@@ -66,3 +66,16 @@ class TestTask:
             f'but related project "{project.name}" starts on {project.start_date.isoformat()}'
         )
         assert expected_message in excinfo.value.messages
+
+    def test_accepts_missing_end_date(self):
+        """Verify that date validation doesn't trigger if `end_date` is missing."""
+        with does_not_raise():
+            TaskFactory(start_date=datetime.date(2024, 1, 1), end_date=None)
+
+    def test_raises_when_ends_before_starting(self):
+        with does_not_raise():
+            # edge case: one day long task
+            _valid = TaskFactory(start_date=datetime.date(2024, 1, 1), end_date=datetime.date(2024, 1, 1))
+
+        with pytest.raises(exceptions.ValidationError, match='must not be later'):
+            _should_fail = TaskFactory(start_date=datetime.date(2024, 1, 1), end_date=datetime.date(2020, 1, 1))

--- a/tests/unit/projects/test_project_models.py
+++ b/tests/unit/projects/test_project_models.py
@@ -5,7 +5,7 @@ import freezegun
 import pytest
 from django.core import exceptions
 
-from testutils.factories import ProjectFactory, TaskFactory
+from testutils.factories import POFactory, ProjectFactory, TaskFactory
 
 
 class TestProject:
@@ -30,6 +30,21 @@ class TestProject:
 
         with pytest.raises(exceptions.ValidationError, match='must not be later'):
             _should_fail = ProjectFactory(start_date=datetime.date(2024, 1, 1), end_date=datetime.date(2020, 1, 1))
+
+
+class TestPO:
+    def test_accepts_missing_end_date(self):
+        """Verify that date validation doesn't trigger if `end_date` is missing."""
+        with does_not_raise():
+            POFactory(start_date=datetime.date(2024, 1, 1), end_date=None)
+
+    def test_raises_when_ends_before_starting(self):
+        with does_not_raise():
+            # edge case: one day long PO
+            _valid = POFactory(start_date=datetime.date(2024, 1, 1), end_date=datetime.date(2024, 1, 1))
+
+        with pytest.raises(exceptions.ValidationError, match='must not be later'):
+            _should_fail = POFactory(start_date=datetime.date(2024, 1, 1), end_date=datetime.date(2020, 1, 1))
 
 
 class TestTask:

--- a/tests/unit/projects/test_tasks.py
+++ b/tests/unit/projects/test_tasks.py
@@ -25,4 +25,4 @@ class TestTask:
             f'task "Invalid" is supposed to start on {datetime.date(2020, 1, 1).isoformat()}, '
             f'but related project "{project.name}" starts on {project.start_date.isoformat()}'
         )
-        assert excinfo.value.message == expected_message
+        assert expected_message in excinfo.value.messages

--- a/tests/unit/timesheet/test_time_entry_model.py
+++ b/tests/unit/timesheet/test_time_entry_model.py
@@ -381,3 +381,13 @@ class TestTimeEntry:
         entry.special_leave_reason = upcoming_reason
         with pytest.raises(exceptions.ValidationError, match='Reason "upcoming" is not valid'):
             entry.save()
+
+    def test_raises_if_ends_before_starting(self):
+        with does_not_raise():
+            # edge case: one day long special leave reason
+            _valid = SpecialLeaveReasonFactory(from_date=datetime.date(2024, 1, 1), to_date=datetime.date(2024, 1, 1))
+
+        with pytest.raises(exceptions.ValidationError, match='must not be later'):
+            _should_fail = SpecialLeaveReasonFactory(
+                from_date=datetime.date(2024, 1, 1), to_date=datetime.date(2020, 1, 1)
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -990,6 +990,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/75/0455fa5029507a2150da59db4f165fbc458ff8bb1c4f4d7e8037a14ad421/freezegun-1.5.2.tar.gz", hash = "sha256:a54ae1d2f9c02dbf42e02c18a3ab95ab4295818b549a34dac55592d72a905181", size = 34855, upload-time = "2025-05-24T12:38:47.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/b2/68d4c9b6431121b6b6aa5e04a153cac41dcacc79600ed6e2e7c3382156f5/freezegun-1.5.2-py3-none-any.whl", hash = "sha256:5aaf3ba229cda57afab5bd311f0108d86b6fb119ae89d2cd9c43ec8c1733c85b", size = 18715, upload-time = "2025-05-24T12:38:45.274Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1214,6 +1226,7 @@ dev = [
     { name = "django-tailwind", extra = ["reload"] },
     { name = "django-webtest" },
     { name = "djangorestframework-stubs" },
+    { name = "freezegun" },
     { name = "opencv-python" },
     { name = "pdbpp" },
     { name = "pre-commit" },
@@ -1315,6 +1328,7 @@ dev = [
     { name = "django-tailwind", extras = ["reload"], specifier = ">=4.0.1" },
     { name = "django-webtest", specifier = ">=1.9.13" },
     { name = "djangorestframework-stubs", specifier = ">=3.15.3" },
+    { name = "freezegun", specifier = ">=1.5.2" },
     { name = "opencv-python", specifier = ">=4.11.0.86" },
     { name = "pdbpp", specifier = ">=0.10.3" },
     { name = "pre-commit", specifier = ">=4.2.0" },


### PR DESCRIPTION
Some models could be saved with their `start_date`/`from_date` field later than their `end_date`/`to_date`. This change fixes this oversight.

This change also avoids relying on signals to trigger pre-save validations, and adds Freezegun as a developer dependency for use in tests.