### PR TITLE
feat(api): Add a restricted active resources list endpoint

### DIFF
--- a/src/krm3/core/api/serializers/user_serializer.py
+++ b/src/krm3/core/api/serializers/user_serializer.py
@@ -7,7 +7,10 @@ from krm3.utils.serializers import ModelDefaultSerializerMetaclass
 User = get_user_model()
 
 
-class ResourceSerializer(metaclass=ModelDefaultSerializerMetaclass):
+# XXX: why is this not a BaseSerializer? The metaclass implicitly
+#      setting the base class in __new__() is making the type checker
+#      go insane
+class UserResourceSerializer(metaclass=ModelDefaultSerializerMetaclass):
     class Meta:
         model = Resource
         fields = '__all__'
@@ -19,9 +22,14 @@ class ProfileSerializer(ModelSerializer):
         fields = '__all__'
 
 
+# XXX: why is this not a BaseSerializer? The metaclass implicitly
+#      setting the base class in __new__() is making the type checker
+#      go insane
 class UserSerializer(metaclass=ModelDefaultSerializerMetaclass):
     profile = ProfileSerializer(required=False, read_only=True, allow_null=True)
-    resource = ResourceSerializer(required=False, read_only=True, allow_null=True)
+    # XXX: since this is NOT a serializer according to the type checker,
+    #      all the kwargs passed to __init__() are flagged as unknown
+    resource = UserResourceSerializer(required=False, read_only=True, allow_null=True)
 
     class Meta:
         model = User

--- a/src/krm3/core/models/auth.py
+++ b/src/krm3/core/models/auth.py
@@ -42,13 +42,23 @@ class User(AbstractUser):
     def get_natural_key_fields() -> list[str]:
         return ['username']
 
-    def can_manage_and_view_any_project(self) -> bool:
+    def can_manage_or_view_any_project(self) -> bool:
         """Check visibility and edit rights for privileged users.
 
-        :return: `True` if the user is allowed to view and edit data on
+        :return: `True` if the user is allowed to view or edit data on
             any project, `False` otherwise.
         """
         return self.has_any_perm('core.manage_any_project', 'core.view_any_project')
+
+    def can_manage_or_view_any_timesheet(self) -> bool:
+        """Check visibility and edit rights for privileged users.
+
+        :return: `True` if the user is allowed to view or edit data on
+            any timesheet, `False` otherwise.
+        """
+        return self.can_manage_or_view_any_project() and self.has_any_perm(
+            'core.manage_any_timesheet', 'core.view_any_timesheet'
+        )
 
     def has_any_perm(self, *perms: str) -> bool:
         """Check that the user has at least one of the given permissions.

--- a/src/krm3/core/models/projects.py
+++ b/src/krm3/core/models/projects.py
@@ -28,7 +28,7 @@ class ProjectManager(NaturalKeyModelManager):
 
         Superuser gets them all.
         """
-        if user.can_manage_and_view_any_project():
+        if user.can_manage_or_view_any_project():
             return self.all()
         return self.filter(mission__resource__profile__user=user)
 
@@ -75,7 +75,7 @@ class Project(NaturalKeyModel):
         return super().clean()
 
     def is_accessible(self, user: User) -> bool:
-        return user.can_manage_and_view_any_project() or self.mission_set.filter(resource__profile__user=user).exists()
+        return user.can_manage_or_view_any_project() or self.mission_set.filter(resource__profile__user=user).exists()
 
 
 class POState(models.TextChoices):

--- a/src/krm3/timesheet/api/views.py
+++ b/src/krm3/timesheet/api/views.py
@@ -37,7 +37,8 @@ class TimesheetAPIViewSet(viewsets.GenericViewSet):
             return Response(data={'error': 'Required query parameter(s) missing.'}, status=status.HTTP_400_BAD_REQUEST)
 
         resource = Resource.objects.get(pk=resource_id)
-        if resource.user != request.user and not cast('User', request.user).can_manage_and_view_any_project():
+        user = cast('User', request.user)
+        if resource.user != request.user and not user.can_manage_or_view_any_timesheet():
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         try:

--- a/tests/unit/core/api/test_core_viewsets.py
+++ b/tests/unit/core/api/test_core_viewsets.py
@@ -1,0 +1,72 @@
+from django.contrib.auth.models import Permission
+import pytest
+from rest_framework.reverse import reverse
+from rest_framework import status
+
+from testutils.factories import ResourceFactory
+
+
+class TestActiveResourcesList:
+    @staticmethod
+    def url():
+        return reverse('core-api:api-resources-active')
+
+    def test_admin_can_request_active_resources(self, admin_user, api_client):
+        active_resource = ResourceFactory(active=True)
+        _inactive_resource = ResourceFactory(active=False)
+
+        response = api_client(user=admin_user).get(self.url())
+        assert response.status_code == status.HTTP_200_OK
+
+        resource_ids = [item.get('id') for item in response.json()]
+        assert resource_ids == [active_resource.id]
+
+    @pytest.mark.parametrize(
+        ('permissions', 'expected_status_code'),
+        (
+            pytest.param([], status.HTTP_403_FORBIDDEN, id='no_perms'),
+            pytest.param(
+                ['manage_any_project'], status.HTTP_403_FORBIDDEN, id='project_manager_without_timesheet_perms'
+            ),
+            pytest.param(
+                ['manage_any_timesheet'], status.HTTP_403_FORBIDDEN, id='timesheet_manager_without_project_perms'
+            ),
+            pytest.param(['view_any_project'], status.HTTP_403_FORBIDDEN, id='project_viewer_without_timesheet_perms'),
+            pytest.param(
+                ['view_any_timesheet'], status.HTTP_403_FORBIDDEN, id='timesheet_viewer_without_project_perms'
+            ),
+            pytest.param(
+                ['view_any_project', 'view_any_timesheet'], status.HTTP_200_OK, id='project_viewer_and_timesheet_viewer'
+            ),
+            pytest.param(
+                ['view_any_project', 'manage_any_timesheet'],
+                status.HTTP_200_OK,
+                id='project_viewer_and_timesheet_manager',
+            ),
+            pytest.param(
+                ['manage_any_project', 'view_any_timesheet'],
+                status.HTTP_200_OK,
+                id='project_manager_and_timesheet_viewer',
+            ),
+            pytest.param(
+                ['manage_any_project', 'manage_any_timesheet'],
+                status.HTTP_200_OK,
+                id='project_manager_and_timesheet_manager',
+            ),
+        ),
+    )
+    def test_regular_user_can_request_active_resources_only_if_authorized(
+        self, permissions, expected_status_code, regular_user, api_client
+    ):
+        active_resource = ResourceFactory(active=True)
+        _inactive_resource = ResourceFactory(active=False)
+
+        for permission in permissions:
+            regular_user.user_permissions.add(Permission.objects.get(codename=permission))
+
+        response = api_client(user=regular_user).get(self.url())
+        assert response.status_code == expected_status_code
+
+        if expected_status_code < 400:
+            resource_ids = [item.get('id') for item in response.json()]
+            assert resource_ids == [active_resource.id]

--- a/tests/unit/projects/test_project_models.py
+++ b/tests/unit/projects/test_project_models.py
@@ -69,8 +69,9 @@ class TestTask:
 
     def test_accepts_missing_end_date(self):
         """Verify that date validation doesn't trigger if `end_date` is missing."""
+        project = ProjectFactory(start_date=datetime.date(2024, 1, 1))
         with does_not_raise():
-            TaskFactory(start_date=datetime.date(2024, 1, 1), end_date=None)
+            TaskFactory(project=project, start_date=datetime.date(2024, 1, 1), end_date=None)
 
     def test_raises_if_ends_before_starting(self):
         project = ProjectFactory(start_date=datetime.date(2024, 1, 1))


### PR DESCRIPTION
This change adds the `/api/v1/core/resource/active/` endpoint.

Adjustments to permission checks had to be made in order to honor manage/view timesheet permissions - we now check that a user has permission to at manage/view both projects and timesheets.