### PR TITLE
Fix missing include upper bound in DateRange psycopg type

### DIFF
--- a/src/krm3/timesheet/api/serializers.py
+++ b/src/krm3/timesheet/api/serializers.py
@@ -211,8 +211,7 @@ class StartEndDateRangeField(serializers.Field):
             upper_date = datetime.date.fromisoformat(upper)
         except ValueError:
             raise serializers.ValidationError('Dates must be in ISO format (YYYY-MM-DD).')
-
-        return DateRange(lower_date, upper_date)
+        return DateRange(lower_date, upper_date, '[]')
 
 
 class TimesheetSubmissionSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Add the upper bound inclusion for DateRange psycopg types (per default it was not included) see ==> https://www.psycopg.org/psycopg3/docs/basic/pgtypes.html#psycopg.types.range.Range (see the `bounds` default attribute)