### PR TITLE
update user last_login field on JWT and social authentication

### DIFF
--- a/src/krm3/config/__init__.py
+++ b/src/krm3/config/__init__.py
@@ -103,7 +103,7 @@ DEFAULTS = dict(  # noqa: C408
 
     SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=(str, '543837936941-6cvmpg79fc93jfq2fv3e4qvtuib3cq9n.apps.googleusercontent.com'),
     SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=(str, ''),
-    SOCIAL_AUTH_ALLOWED_REDIRECT_URIS=(list, ['http://localhost:3000/login', 'https://localhost:3000/login']),
+    SOCIAL_AUTH_ALLOWED_REDIRECT_URIS=(list, ['http://localhost:3000/login', 'http://localhost:8000/login']),
     SOCIAL_AUTH_GOOGLE_OAUTH2_WHITELISTED_DOMAINS=(list, ['k-tech.it']),
 
     HOLIDAYS_CALENDAR=(str, 'IT-RM')

--- a/src/krm3/config/fragments/social.py
+++ b/src/krm3/config/fragments/social.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 
 from django.contrib import messages
 from django.shortcuts import redirect
+from django.utils import timezone
 
 from ..environ import env as _env
 
@@ -32,6 +33,7 @@ if SOCIAL_AUTH_GOOGLE_OAUTH2_KEY := _env('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY'):
         'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
         'REFRESH_TOKEN_LIFETIME': timedelta(days=30),
         'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+        'UPDATE_LAST_LOGIN': True,
     }
 
     DJOSER = {
@@ -61,6 +63,7 @@ if SOCIAL_AUTH_GOOGLE_OAUTH2_KEY := _env('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY'):
         'social_core.pipeline.user.user_details',
         'krm3.config.fragments.social.update_user_social_data',
         'krm3.config.fragments.social.associate_resource',
+        'krm3.config.fragments.social.update_last_login',
     )
 
     SOCIAL_AUTH_STRATEGY = 'social_django.strategy.DjangoStrategy'
@@ -129,3 +132,8 @@ if SOCIAL_AUTH_GOOGLE_OAUTH2_KEY := _env('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY'):
             resource.save()
         except Resource.DoesNotExist:
             pass
+
+    def update_last_login(strategy: 'BaseStrategy', user: 'User', *args, **kwargs) -> None:
+        if user:
+            user.last_login = timezone.now()
+            user.save()

--- a/src/krm3/core/apps.py
+++ b/src/krm3/core/apps.py
@@ -1,7 +1,7 @@
-from django.apps import AppConfig
+from django.apps import AppConfig as BaseAppConfig
 
 
-class AppConfig(AppConfig):
+class AppConfig(BaseAppConfig):
     name = 'krm3.core'
 
     def ready(self) -> None:


### PR DESCRIPTION
What has been done:

- Set the `UPDATE_LAST_LOGIN` settings to `True` for the Simple JWT Authentication
- Add a custom `SOCIAL_AUTH_PIPELINE` pipeline function to update `last_login` field upon social 3rd party authentication

Chore:
- refactor the core `AppConfig` aliasing the parent class to avoid ugly class name clashing
- added `http://localhost:8000/login` as default login callback URI to allow social login also when running the app having the frontend served as static script by Django 
