### PR TITLE
enhance timesheet api with task title

### DIFF
--- a/src/krm3/timesheet/api/serializers.py
+++ b/src/krm3/timesheet/api/serializers.py
@@ -22,6 +22,7 @@ class BaseTimeEntrySerializer(serializers.ModelSerializer):
 
 class TimeEntryReadSerializer(BaseTimeEntrySerializer):
     last_modified = serializers.SerializerMethodField()
+    task_title = serializers.SerializerMethodField()
 
     class Meta(BaseTimeEntrySerializer.Meta):
         fields = (
@@ -41,11 +42,17 @@ class TimeEntryReadSerializer(BaseTimeEntrySerializer):
             # 'state',
             'comment',
             'task',
+            'task_title',
         )
         read_only_fields = fields
 
     def get_last_modified(self, obj: TimeEntry) -> str:
         return obj.last_modified.isoformat()
+
+    def get_task_title(self, obj: TimeEntry) -> str | None:
+        if not obj.task:
+            return None
+        return obj.task.title
 
 
 class TimeEntryCreateSerializer(BaseTimeEntrySerializer):

--- a/src/krm3/timesheet/api/views.py
+++ b/src/krm3/timesheet/api/views.py
@@ -23,6 +23,7 @@ from krm3.timesheet.api.serializers import (
     TimeEntryCreateSerializer,
     TimesheetSerializer,
 )
+from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 from krm3.timesheet.report import timesheet_report_data
 
@@ -35,6 +36,25 @@ class TimesheetAPIViewSet(viewsets.GenericViewSet):
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = TimesheetSerializer
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name='resource_id',
+                type=int,
+                required=True,
+            ),
+            OpenApiParameter(
+                name='start_date',
+                type=str,
+                required=True,
+            ),
+            OpenApiParameter(
+                name='end_date',
+                type=str,
+                required=True,
+            ),
+        ]
+    )
     def list(self, request: Request) -> Response:
         try:
             resource_id = request.query_params['resource_id']

--- a/tests/api/timesheet/test_task_viewset.py
+++ b/tests/api/timesheet/test_task_viewset.py
@@ -193,6 +193,7 @@ class TestTaskAPIListView:
                     'restHours': _as_quantized_decimal(task_entry_within_range.rest_hours),
                     'comment': 'Within range',
                     'task': task.pk,
+                    'taskTitle': task.title,
                 },
                 {
                     'id': day_entry_within_range.id,
@@ -210,6 +211,7 @@ class TestTaskAPIListView:
                     'restHours': _as_quantized_decimal(day_entry_within_range.rest_hours),
                     'comment': 'Within range (day)',
                     'task': None,
+                    'taskTitle': None,
                 },
             ],
             'days': {


### PR DESCRIPTION
- Added `taskTitle` field in the TimeEntrySerializer
- Enhanced the swagger UI of `api/v1/timesheet` endpoint to include the required query params 