### PR TITLE
feat(report): rework report generation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.6.0 (2026-05-06)
+
+### Feat
+
+- **Admin**: ContractAdmin button to close contract and tasks. Fix search in contractadmin
+
 ## 3.5.4 (2026-04-28)
 
 ## 3.5.3 (2026-04-28)

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -7,7 +7,7 @@ $(error DOCKER_REGISTRY is not set)
 endif
 
 # VARIABLES
-VERSION=3.5.4
+VERSION=3.6.0
 BASE?=$(shell echo "${VERSION}" | sed "s/\([0-9]*\)\.\([0-9]*\)\.\(.*\)/\1.\2/g" )
 BUILDDIR?=./~build
 CONTAINER_NAME=kt-krm3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "krm3"
-version = "3.5.4"
+version = "3.6.0"
 description = "KRM3"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/krm3/__init__.py
+++ b/src/krm3/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'K-Tech team'
-__version__ = '3.5.4'
+__version__ = '3.6.0'
 __name__ = 'krm3'

--- a/src/krm3/config/fragments/serviceworker.js
+++ b/src/krm3/config/fragments/serviceworker.js
@@ -1,6 +1,6 @@
 // Base Service Worker implementation.  To use your own Service Worker, set the PWA_SERVICE_WORKER_PATH variable in settings.py
 
-const _version = "3.5.4"
+const _version = "3.6.0"
 
 var staticCacheName = "krm3-v" + _version + "-" + new Date().getTime();
 var filesToCache = [

--- a/src/krm3/core/admin.py
+++ b/src/krm3/core/admin.py
@@ -1,19 +1,42 @@
-from adminfilters.autocomplete import AutoCompleteFilter
-from adminfilters.mixin import AdminFiltersMixin
+import datetime
+from datetime import timedelta
+
 from admin_extra_buttons.decorators import button
 from admin_extra_buttons.mixins import ExtraButtonsMixin
-from django.contrib import admin
+from adminfilters.autocomplete import AutoCompleteFilter
+from adminfilters.mixin import AdminFiltersMixin
+from django.contrib import admin, messages
 from django.contrib.admin import ModelAdmin
 from django.contrib.admin.widgets import AdminDateWidget
 from django.contrib.postgres.fields import DateRangeField
 from django.contrib.postgres.forms import RangeWidget
-from django.http import HttpRequest
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
 from django.utils.html import format_html
 from smart_admin.smart_auth.admin import UserAdmin
 
-from krm3.core.forms import ContractForm
-from krm3.core.models import City, Client, Contract, Country, ExtraHoliday, Resource, UserProfile, \
-    Contact, AddressInfo, EmailInfo, PhoneInfo, WebsiteInfo, Website, Phone, Email, Address
+from krm3.core.forms import ContractForm, ContractTerminationForm
+from krm3.core.models import (
+    Address,
+    AddressInfo,
+    City,
+    Client,
+    Contact,
+    Contract,
+    Country,
+    Email,
+    EmailInfo,
+    ExtraHoliday,
+    Phone,
+    PhoneInfo,
+    Resource,
+    Task,
+    UserProfile,
+    Website,
+    WebsiteInfo,
+)
+from krm3.styles.buttons import DANGEROUS
 
 
 @admin.register(UserProfile)
@@ -76,9 +99,9 @@ class ClientAdmin(ModelAdmin):
 
 
 @admin.register(Contract)
-class ContractAdmin(AdminFiltersMixin, ModelAdmin):
+class ContractAdmin(ExtraButtonsMixin, AdminFiltersMixin, ModelAdmin):
     form = ContractForm
-    search_fields = ['user']
+    search_fields = ['resource__last_name', 'resource__first_name']
     list_display = [
         'resource',
         'get_period',
@@ -105,6 +128,30 @@ class ContractAdmin(AdminFiltersMixin, ModelAdmin):
         if obj.document_url:
             return format_html('<a href="{}">View document</a>', obj.document_url)
         return '-'
+
+    @button(html_attrs=DANGEROUS, visible=lambda btn: not btn.original.period.upper)
+    def terminate(self, request: HttpRequest, pk: str) -> HttpResponse:
+        contract = get_object_or_404(Contract, pk=pk)
+        context = self.get_common_context(request, pk, title='Terminate Contract')
+
+        if request.method == 'POST':
+            form = ContractTerminationForm(request.POST)
+            if form.is_valid():
+                from django.contrib.postgres.fields.ranges import DateRange
+
+                termination_date = form.cleaned_data['termination_date']
+                contract.period = DateRange(contract.period.lower, termination_date + timedelta(days=1))
+                contract.save()
+                updated = Task.objects.filter(resource=contract.resource, end_date__isnull=True).update(
+                    end_date=termination_date
+                )
+                messages.success(request, f'Contract terminated. {updated} task(s) updated.')
+                return redirect('admin:core_contract_changelist')
+        else:
+            form = ContractTerminationForm(initial={'termination_date': datetime.date.today()})
+
+        context['form'] = form
+        return TemplateResponse(request, 'admin/core/contract/terminate.html', context)
 
 
 @admin.register(ExtraHoliday)
@@ -151,9 +198,10 @@ class ContactAdmin(ExtraButtonsMixin, admin.ModelAdmin):
         AddressInfoInline,
     ]
 
-    @button(label="fetch photo")
+    @button(label='fetch photo')
     def fetch_picture(self, request: HttpRequest, contact_id: str) -> None:
         Contact.objects.get(pk=contact_id).fetch_picture()
+
 
 @admin.register(Website)
 class WebsiteAdmin(admin.ModelAdmin):

--- a/src/krm3/core/forms.py
+++ b/src/krm3/core/forms.py
@@ -2,9 +2,10 @@ import datetime
 import typing
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import ModelForm
-from django.conf import settings
+from django.utils.translation import gettext_lazy as _l
 
 from krm3.core.models import Contract, ProtectedDocument
 from krm3.core.widgets import PrivateMediaFileInput
@@ -49,7 +50,7 @@ class ContractForm(ModelForm):
                 for task in self.instance.get_tasks():
                     task_period = [task.start_date, task.end_date or DATE_INFINITE]
                     if (new_period[0] > old_period[0] and new_period[0] > task_period[0]) or (
-                            new_period[1] < old_period[1] and new_period[1] - datetime.timedelta(days=1) < task_period[1]
+                        new_period[1] < old_period[1] and new_period[1] - datetime.timedelta(days=1) < task_period[1]
                     ):
                         raise ValidationError('Shrinking contract period would leave orphan tasks', code='orphan-tasks')
 
@@ -69,10 +70,12 @@ class ResourceForm(forms.Form):
     preferred_language = forms.ChoiceField(
         choices=settings.LANGUAGES,
         required=False,
-        widget=forms.Select(attrs={
-            "style": "color: black;",
-            "class": "language-select",
-        })
+        widget=forms.Select(
+            attrs={
+                'style': 'color: black;',
+                'class': 'language-select',
+            }
+        ),
     )
 
     def __init__(self, resource: 'Resource', *args: typing.Any, **kwargs: typing.Any) -> None:
@@ -102,3 +105,13 @@ class ProtectedDocumentForm(ModelForm):
         widgets = {
             'document': PrivateMediaFileInput(url_field='file_url'),
         }
+
+
+class ContractTerminationForm(forms.Form):
+    termination_date = forms.DateField(
+        widget=forms.DateInput(attrs={'type': 'date'}),
+        help_text=_l(
+            'Actual end date of the contract. Tasks without end date for this resource will be updated to this date.'
+        ),
+        label=_l('Contract end date'),
+    )

--- a/src/krm3/core/models/auth.py
+++ b/src/krm3/core/models/auth.py
@@ -3,24 +3,28 @@ from __future__ import annotations
 import datetime
 import json
 from decimal import Decimal
-from typing import Any, Self, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Self
 
+import vobject
+from constance import config
 from django.contrib.auth.base_user import BaseUserManager
+from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ValidationError
-from django.db.models import Sum
-from natural_keys import NaturalKeyModel
 from django.db import models
+from django.db.models import Sum
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.contrib.auth.models import AbstractUser
-import vobject
+from natural_keys import NaturalKeyModel
+
+# TODO: from Python 3.13 on, `deprecated` should be imported from `warnings`
+from typing_extensions import deprecated
 
 from krm3.config import settings
 from krm3.utils.dates import KrmCalendar, KrmDay
-from constance import config
 
 if TYPE_CHECKING:
     from datetime import date
+
     from krm3.core.models import Contract
 
 
@@ -209,16 +213,24 @@ class Resource(models.Model):
 
         return days_list
 
-    def get_contracts(self, start_day: date, end_day: date) -> list[Contract]:
+    def get_contracts(self, start_day: date, end_day: date | None, including_end: bool = True) -> list[Contract]:
         """Return a list of contracts applicable to the time interval between start_day and end_day."""
         from krm3.core.models import Contract  # noqa: PLC0415
 
         return list(
             Contract.objects.filter(
-                period__overlap=(start_day, end_day + datetime.timedelta(days=1) if end_day else None), resource=self
+                period__overlap=(start_day, end_day + datetime.timedelta(days=int(including_end)) if end_day else None),
+                resource=self,
             )
         )
 
+    def get_contract_for_date(self, day: date | KrmDay) -> Contract | None:
+        try:
+            return self.get_contracts(day, day)[0]
+        except IndexError:
+            return None
+
+    @deprecated('Use `get_contract_for_date()` instead')
     def contract_for_date(self, contract_list: 'list[Contract]', day: date | KrmDay) -> 'Contract | None':
         """Select the contract applicable for the given day."""
         for contract in contract_list:

--- a/src/krm3/core/models/auth.py
+++ b/src/krm3/core/models/auth.py
@@ -213,8 +213,21 @@ class Resource(models.Model):
         return days_list
 
     def get_contracts(self, start_day: date, end_day: date | None, including_end: bool = True) -> list[Contract]:
-        """Return a list of contracts applicable to the time interval between start_day and end_day."""
-        from krm3.core.models import Contract  # noqa: PLC0415
+        """Return this resource's contracts valid during a given interval.
+
+        The contracts are returned as a list, not a queryset.
+
+        :param start_day: the start of the focus interval
+        :param end_day: the end of the focus interval. If `None`,
+            the interval is considered unbounded.
+        :param including_end: whether or not the interval is inclusive
+            at the end. Ignored if `end_day` is `None`. Defaults to
+            `True`. If you are working with intervals coming from
+            Postgres `DateRange`s, you might want to set it to `False`
+            to avoid boilerplate.
+        :return: a list of contracts
+        """
+        from krm3.core.models import Contract  # noqa: PLC0415 - workaround for circular import
 
         return list(
             cast('ContractQuerySet', Contract.objects)
@@ -223,8 +236,17 @@ class Resource(models.Model):
         )
 
     def get_contract_for_date(self, day: date | KrmDay) -> Contract | None:
+        """Return the contract this resource had on the given `day`.
+
+        :param day: the focus date
+        :return: a contract, or `None` if not found.
+        """
         day = KrmDay(day).date
         try:
+            # get the contract in the single-day interval containing the
+            # focus day.
+            # contracts never overlap due to business rules, so we are
+            # guaranteed to find at most one contract in a given day
             return self.get_contracts(day, day)[0]
         except IndexError:
             return None

--- a/src/krm3/core/models/auth.py
+++ b/src/krm3/core/models/auth.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import datetime
 import json
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Self, cast
 
 import vobject
 from constance import config
@@ -25,7 +24,7 @@ from krm3.utils.dates import KrmCalendar, KrmDay
 if TYPE_CHECKING:
     from datetime import date
 
-    from krm3.core.models import Contract
+    from krm3.core.models import Contract, ContractQuerySet
 
 
 class UserManager(BaseUserManager):
@@ -218,13 +217,13 @@ class Resource(models.Model):
         from krm3.core.models import Contract  # noqa: PLC0415
 
         return list(
-            Contract.objects.filter(
-                period__overlap=(start_day, end_day + datetime.timedelta(days=int(including_end)) if end_day else None),
-                resource=self,
-            )
+            cast('ContractQuerySet', Contract.objects)
+            .active_between(start_day, end_day, including_end)
+            .filter(resource=self)
         )
 
     def get_contract_for_date(self, day: date | KrmDay) -> Contract | None:
+        day = KrmDay(day).date
         try:
             return self.get_contracts(day, day)[0]
         except IndexError:

--- a/src/krm3/core/models/contracts.py
+++ b/src/krm3/core/models/contracts.py
@@ -26,7 +26,13 @@ class ContractQuerySet(models.QuerySet['Contract']):
         """Return the contracts valid in the given interval.
 
         :param start: the start of the interval (inclusive).
-        :param end: the end of the interval (inclusive).
+        :param end: the end of the interval. If `None`, the interval is
+            considered unbounded.
+        :param including_end: whether or not the interval is inclusive
+            at the end. Ignored if `end_day` is `None`. Defaults to
+            `True`. If you are working with intervals coming from
+            Postgres `DateRange`s, you might want to set it to `False`
+            to avoid boilerplate.
         :return: the filtered `Contract`s.
         """
         if not end:

--- a/src/krm3/core/models/contracts.py
+++ b/src/krm3/core/models/contracts.py
@@ -21,14 +21,14 @@ if TYPE_CHECKING:
 
 
 class ContractQuerySet(models.QuerySet['Contract']):
-    def active_between(self, start: datetime.date, end: datetime.date) -> Self:
+    def active_between(self, start: datetime.date, end: datetime.date, including_end: bool = True) -> Self:
         """Return the contracts valid in the given interval.
 
         :param start: the start of the interval (inclusive).
         :param end: the end of the interval (inclusive).
         :return: the filtered `Contract`s.
         """
-        end = end + datetime.timedelta(days=1)
+        end = end + datetime.timedelta(days=int(including_end))
         return self.filter(period__overlap=(start, end))
 
     def accessible_by(self, user: 'User') -> Self:

--- a/src/krm3/core/models/contracts.py
+++ b/src/krm3/core/models/contracts.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING, Self
 
@@ -21,15 +22,25 @@ if TYPE_CHECKING:
 
 
 class ContractQuerySet(models.QuerySet['Contract']):
-    def active_between(self, start: datetime.date, end: datetime.date, including_end: bool = True) -> Self:
+    def active_between(self, start: datetime.date, end: datetime.date | None, including_end: bool = True) -> Self:
         """Return the contracts valid in the given interval.
 
         :param start: the start of the interval (inclusive).
         :param end: the end of the interval (inclusive).
         :return: the filtered `Contract`s.
         """
+        if not end:
+            return self.active_from(start)
         end = end + datetime.timedelta(days=int(including_end))
         return self.filter(period__overlap=(start, end))
+
+    def active_from(self, start: datetime.date) -> Self:
+        """Return the contracts valid from a given `start` date.
+
+        :param start: a `datetime.date`
+        :return: the filtered `Contract`s.
+        """
+        return self.filter(period__overlap=(start, None))
 
     def accessible_by(self, user: 'User') -> Self:
         """Return contracts accessible by the given user.
@@ -46,8 +57,6 @@ class ContractQuerySet(models.QuerySet['Contract']):
             QuerySet of accessible contracts
 
         """
-        import logging
-
         logger = logging.getLogger(__name__)
 
         # Superuser has access to all contracts

--- a/src/krm3/missions/templates/admin/core/contract/terminate.html
+++ b/src/krm3/missions/templates/admin/core/contract/terminate.html
@@ -1,0 +1,14 @@
+{% extends "admin/base.html" %}
+{% load static %}
+
+{% block container %}
+    {% block content %}
+        <form action="#" method="post" enctype="multipart/form-data">
+            {% csrf_token %}
+            {{ form }}
+            <input type=submit>
+        </form>
+        <br>
+        <a href="{% url 'admin:core_contract_change' original.id %}">Back to Contract {{ original }}</a>
+    {% endblock %}
+{% endblock %}

--- a/src/krm3/reports/availability.py
+++ b/src/krm3/reports/availability.py
@@ -1,0 +1,86 @@
+from collections import defaultdict
+from decimal import Decimal
+from enum import Enum
+from typing import TYPE_CHECKING, cast, override
+
+import tablib
+from django.utils.translation import gettext_lazy
+
+from krm3.core.models.auth import Resource
+from krm3.core.models.contracts import Contract, ContractQuerySet
+from krm3.core.models.projects import Project
+from krm3.core.models.timesheets import TimeEntry, TimeEntryQuerySet
+from krm3.reports.generator import Period, ReportGenerator
+
+if TYPE_CHECKING:
+    import datetime
+
+
+class _AbsenceKind(Enum):
+    HOLIDAY = gettext_lazy('H')
+    SICK = gettext_lazy('S')
+    LEAVE = gettext_lazy('L')
+    SPECIAL_LEAVE = gettext_lazy('SL')
+    REST = gettext_lazy('R')
+
+
+_ABSENCE_SHOW_HOURS = {_AbsenceKind.LEAVE, _AbsenceKind.SPECIAL_LEAVE, _AbsenceKind.REST}
+
+
+class AvailabilityReport(ReportGenerator):
+    @override
+    def __init__(self, period: Period, project: Project | None) -> None:
+        start, end = period
+        self.contracts = cast('ContractQuerySet', Contract.objects).active_between(start, end, including_end=False)
+        self.resources = Resource.objects.filter(id__in=self.contracts.values_list('resource_id').distinct()).order_by(
+            'last_name'
+        )
+        if project:
+            self.resources = self.resources.prefetch_related('task_set').filter(task__project=project)
+
+        super().__init__(period, project)
+
+    @override
+    def collect(self, _project: Project | None) -> TimeEntryQuerySet:
+        return cast(
+            'TimeEntryQuerySet',
+            TimeEntry.objects.filter(
+                date__gte=self.start, date__lt=self.end, resource__in=self.resources
+            ).select_related('special_leave_reason'),
+        )
+
+    def process(self, time_entries: TimeEntryQuerySet) -> tablib.Dataset:
+        entries_by_key: dict[tuple[int, datetime.date], list[TimeEntry]] = defaultdict(list)
+        for entry in time_entries:
+            entries_by_key[(entry.resource.id, entry.date)].append(entry)
+
+        headers = ['Resource'] + [d.strftime('%a %d') for d in self.dates]
+        dataset = tablib.Dataset(headers=headers)
+
+        for resource in self.resources:
+            row = [f'{resource.first_name} {resource.last_name}']
+            for date in self.dates:
+                entries = entries_by_key.get((resource.pk, date), [])
+                row.append(self._compute_absences(entries))  # pyright: ignore
+            dataset.append(row)
+
+        return dataset
+
+    def _compute_absences(self, entries: list[TimeEntry]) -> list[tuple[_AbsenceKind, Decimal]]:
+        absences: list[tuple[_AbsenceKind, Decimal]] = []
+
+        for entry in entries:
+            if entry.holiday_hours > 0:
+                absences.append((_AbsenceKind.HOLIDAY, entry.holiday_hours))
+                break
+            if entry.sick_hours > 0:
+                absences.append((_AbsenceKind.SICK, entry.sick_hours))
+                break
+            if entry.leave_hours > 0:
+                absences.append((_AbsenceKind.LEAVE, entry.leave_hours))
+            if entry.special_leave_hours > 0:
+                absences.append((_AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours))
+            if entry.rest_hours > 0:
+                absences.append((_AbsenceKind.REST, entry.rest_hours))
+
+        return absences

--- a/src/krm3/reports/availability.py
+++ b/src/krm3/reports/availability.py
@@ -67,7 +67,7 @@ class AvailabilityReport(ReportGenerator):
         super().__init__(period, project)
 
     @override
-    def collect(self, project: str | Project | None) -> TimeEntryQuerySet:
+    def _collect(self, project: str | Project | None) -> TimeEntryQuerySet:
         if isinstance(project, str):
             project = Project.objects.get(id=project)
         if project:
@@ -75,12 +75,12 @@ class AvailabilityReport(ReportGenerator):
         return cast(
             'TimeEntryQuerySet',
             TimeEntry.objects.filter(
-                date__gte=self.start, date__lt=self.end, resource__in=self.resources
+                date__gte=self.period_start, date__lt=self.period_end, resource__in=self.resources
             ).select_related('special_leave_reason'),
         )
 
     @override
-    def process(self, time_entries: TimeEntryQuerySet) -> tablib.Dataset:
+    def _process(self, time_entries: TimeEntryQuerySet) -> tablib.Dataset:
         entries_by_key: dict[tuple[int, datetime.date], list[TimeEntry]] = defaultdict(list)
         for entry in time_entries:
             entries_by_key[(entry.resource.id, entry.date)].append(entry)

--- a/src/krm3/reports/availability.py
+++ b/src/krm3/reports/availability.py
@@ -36,7 +36,7 @@ class Absence(NamedTuple):
         return f'{self.kind.value} {displayed_hours}'.rstrip()
 
 
-@dataclass
+@dataclass(frozen=True)
 class AbsenceReportCell:
     date: datetime.date
     resource: Resource

--- a/src/krm3/reports/availability.py
+++ b/src/krm3/reports/availability.py
@@ -51,25 +51,27 @@ class AbsenceReportCell:
 
 
 class AvailabilityReport(ReportGenerator):
+    """The availability report generator."""
+
     @override
     def __init__(self, period: Period, project: str | Project | None) -> None:
         start, end = period
         contracts = cast('ContractQuerySet', Contract.objects).active_between(start, end, including_end=True)
-        resources = (
+        self.resources = (
             Resource.objects.filter(id__in=contracts.values_list('resource_id').distinct())
             .order_by('last_name')
             .prefetch_related('task_set')
+            .distinct()
         )
-        if isinstance(project, str):
-            project = Project.objects.get(id=project)
-        if project:
-            resources = resources.filter(task__project=project)
-        self.resources = resources.distinct()
 
         super().__init__(period, project)
 
     @override
-    def collect(self, project: Project | None) -> TimeEntryQuerySet:
+    def collect(self, project: str | Project | None) -> TimeEntryQuerySet:
+        if isinstance(project, str):
+            project = Project.objects.get(id=project)
+        if project:
+            self.resources = self.resources.filter(task__project=project)
         return cast(
             'TimeEntryQuerySet',
             TimeEntry.objects.filter(

--- a/src/krm3/reports/availability.py
+++ b/src/krm3/reports/availability.py
@@ -1,7 +1,9 @@
+import datetime
 from collections import defaultdict
+from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import Enum
-from typing import TYPE_CHECKING, cast, override
+from typing import NamedTuple, cast, override
 
 import tablib
 from django.utils.translation import gettext_lazy
@@ -11,12 +13,10 @@ from krm3.core.models.contracts import Contract, ContractQuerySet
 from krm3.core.models.projects import Project
 from krm3.core.models.timesheets import TimeEntry, TimeEntryQuerySet
 from krm3.reports.generator import Period, ReportGenerator
-
-if TYPE_CHECKING:
-    import datetime
+from krm3.timesheet.rules import Krm3Day
 
 
-class _AbsenceKind(Enum):
+class AbsenceKind(Enum):
     HOLIDAY = gettext_lazy('H')
     SICK = gettext_lazy('S')
     LEAVE = gettext_lazy('L')
@@ -24,24 +24,52 @@ class _AbsenceKind(Enum):
     REST = gettext_lazy('R')
 
 
-_ABSENCE_SHOW_HOURS = {_AbsenceKind.LEAVE, _AbsenceKind.SPECIAL_LEAVE, _AbsenceKind.REST}
+_ABSENCE_SHOW_HOURS = {AbsenceKind.LEAVE, AbsenceKind.SPECIAL_LEAVE, AbsenceKind.REST}
+
+
+class Absence(NamedTuple):
+    kind: AbsenceKind
+    hours: Decimal
+
+    def __str__(self) -> str:
+        displayed_hours = self.hours if self.kind in _ABSENCE_SHOW_HOURS else ''
+        return f'{self.kind.value} {displayed_hours}'.rstrip()
+
+
+@dataclass
+class AbsenceReportCell:
+    date: datetime.date
+    resource: Resource
+    absences: list[Absence] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        return ', '.join(str(absence) for absence in self.absences)
+
+    def is_working_day(self) -> bool:
+        contract = self.resource.get_contract_for_date(self.date)
+        return contract is not None and Krm3Day(self.date).is_working_day(contract.country_calendar_code)
 
 
 class AvailabilityReport(ReportGenerator):
     @override
-    def __init__(self, period: Period, project: Project | None) -> None:
+    def __init__(self, period: Period, project: str | Project | None) -> None:
         start, end = period
-        self.contracts = cast('ContractQuerySet', Contract.objects).active_between(start, end, including_end=False)
-        self.resources = Resource.objects.filter(id__in=self.contracts.values_list('resource_id').distinct()).order_by(
-            'last_name'
+        contracts = cast('ContractQuerySet', Contract.objects).active_between(start, end, including_end=True)
+        resources = (
+            Resource.objects.filter(id__in=contracts.values_list('resource_id').distinct())
+            .order_by('last_name')
+            .prefetch_related('task_set')
         )
+        if isinstance(project, str):
+            project = Project.objects.get(id=project)
         if project:
-            self.resources = self.resources.prefetch_related('task_set').filter(task__project=project)
+            resources = resources.filter(task__project=project)
+        self.resources = resources.distinct()
 
         super().__init__(period, project)
 
     @override
-    def collect(self, _project: Project | None) -> TimeEntryQuerySet:
+    def collect(self, project: Project | None) -> TimeEntryQuerySet:
         return cast(
             'TimeEntryQuerySet',
             TimeEntry.objects.filter(
@@ -49,6 +77,7 @@ class AvailabilityReport(ReportGenerator):
             ).select_related('special_leave_reason'),
         )
 
+    @override
     def process(self, time_entries: TimeEntryQuerySet) -> tablib.Dataset:
         entries_by_key: dict[tuple[int, datetime.date], list[TimeEntry]] = defaultdict(list)
         for entry in time_entries:
@@ -61,26 +90,27 @@ class AvailabilityReport(ReportGenerator):
             row = [f'{resource.first_name} {resource.last_name}']
             for date in self.dates:
                 entries = entries_by_key.get((resource.pk, date), [])
-                row.append(self._compute_absences(entries))  # pyright: ignore
+                absences = self._compute_absences(entries)
+                row.append(AbsenceReportCell(date, resource, absences))  # pyright: ignore
             dataset.append(row)
 
         return dataset
 
-    def _compute_absences(self, entries: list[TimeEntry]) -> list[tuple[_AbsenceKind, Decimal]]:
-        absences: list[tuple[_AbsenceKind, Decimal]] = []
+    def _compute_absences(self, entries: list[TimeEntry]) -> list[Absence]:
+        absences = []
 
         for entry in entries:
             if entry.holiday_hours > 0:
-                absences.append((_AbsenceKind.HOLIDAY, entry.holiday_hours))
+                absences.append(Absence(AbsenceKind.HOLIDAY, entry.holiday_hours))
                 break
             if entry.sick_hours > 0:
-                absences.append((_AbsenceKind.SICK, entry.sick_hours))
+                absences.append(Absence(AbsenceKind.SICK, entry.sick_hours))
                 break
             if entry.leave_hours > 0:
-                absences.append((_AbsenceKind.LEAVE, entry.leave_hours))
+                absences.append(Absence(AbsenceKind.LEAVE, entry.leave_hours))
             if entry.special_leave_hours > 0:
-                absences.append((_AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours))
+                absences.append(Absence(AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours))
             if entry.rest_hours > 0:
-                absences.append((_AbsenceKind.REST, entry.rest_hours))
+                absences.append(Absence(AbsenceKind.REST, entry.rest_hours))
 
         return absences

--- a/src/krm3/reports/generator.py
+++ b/src/krm3/reports/generator.py
@@ -34,7 +34,7 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         """
         ...
 
-    def render[RD, F](self, renderer: Renderer[RD, F]) -> F:
+    def render[F](self, renderer: Renderer[RD, F]) -> F:
         """Transform `self.report_data` into a human-readable format.
 
         :param renderer: The transformation `Callable` to apply
@@ -44,14 +44,28 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
 
     @property
     def start(self) -> datetime.date:
+        """The start of the reporting period.
+
+        :return: a `datetime.date`.
+        """
         return self.period[0]
 
     @property
     def end(self) -> datetime.date:
+        """The end of the reporting period.
+
+        :return: a `datetime.date`.
+        """
         return self.period[1]
 
     @property
     def dates(self) -> list[datetime.date]:
+        """All the dates within the reporting period.
+
+        Mainly used for dataset headers.
+
+        :return: a list of `datetime.date` objects.
+        """
         result = []
         current = self.start
         while current < self.end:

--- a/src/krm3/reports/generator.py
+++ b/src/krm3/reports/generator.py
@@ -39,11 +39,11 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         :param period: the focus date range for the report.
         """
         self.period = period
-        time_entries = self.collect(*args, **kwargs)
-        self.processed_data = self.process(time_entries)
+        time_entries = self._collect(*args, **kwargs)
+        self.processed_data = self._process(time_entries)
 
     @abc.abstractmethod
-    def collect(self, *args: P.args, **kwargs: P.kwargs) -> TimeEntryQuerySet:
+    def _collect(self, *args: P.args, **kwargs: P.kwargs) -> TimeEntryQuerySet:
         """Collect the time entries on which the report should be generated.
 
         :return: a Django queryset of `TimeEntry`.
@@ -51,7 +51,7 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         ...
 
     @abc.abstractmethod
-    def process(self, time_entries: TimeEntryQuerySet) -> RD:
+    def _process(self, time_entries: TimeEntryQuerySet) -> RD:
         """Aggregate the time entry data in order to form a tabular report.
 
         :param time_entries: the input time entries
@@ -60,7 +60,7 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         ...
 
     def render[F](self, renderer: Renderer[RD, F]) -> F:
-        """Transform `self.report_data` into a different format.
+        """Transform `self.processed_data` into a different format.
 
         :param renderer: The transformation `Callable` to apply
         :return: The result of the transformation
@@ -68,7 +68,7 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         return renderer(self.processed_data)
 
     @property
-    def start(self) -> datetime.date:
+    def period_start(self) -> datetime.date:
         """The start of the reporting period.
 
         :return: a `datetime.date`.
@@ -76,7 +76,7 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         return self.period[0]
 
     @property
-    def end(self) -> datetime.date:
+    def period_end(self) -> datetime.date:
         """The end of the reporting period.
 
         :return: a `datetime.date`.
@@ -92,8 +92,8 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         :return: a list of `datetime.date` objects.
         """
         result = []
-        current = self.start
-        while current < self.end:
+        current = self.period_start
+        while current < self.period_end:
             result.append(current)
             current += datetime.timedelta(days=1)
         return result

--- a/src/krm3/reports/generator.py
+++ b/src/krm3/reports/generator.py
@@ -1,6 +1,6 @@
 import abc
-from collections.abc import Callable
 import datetime
+from collections.abc import Callable
 
 import tablib
 
@@ -12,7 +12,32 @@ type Renderer[RD: ProcessedReportData, F] = Callable[[RD], F]
 
 
 class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
+    """ABC for report generation flows.
+
+    Report flows are functional-like pipelines:
+
+    * `collect()` loads the time entries involved in the report;
+    * `process()` aggregates them into a `tablib.Databook` or
+      `tablib.Dataset`
+    * optionally, `render()` applies a rendering callable to the
+      aggregated report data to produce a representation of the latter
+      in a different format.
+
+    For convenience's sake, these flows are wrapped into a class so that
+    subclasses can set up shared state between all steps.
+
+    :param period: the focus date range for the report
+    :param processed_data: the aggregated report data
+    """
+
     def __init__(self, period: Period, *args: P.args, **kwargs: P.kwargs) -> None:
+        """Automatically collect and aggregate report data.
+
+        This is a good place to pre-fetch additional data if needed by
+        both the collection and the aggregation step.
+
+        :param period: the focus date range for the report.
+        """
         self.period = period
         time_entries = self.collect(*args, **kwargs)
         self.processed_data = self.process(time_entries)
@@ -35,7 +60,7 @@ class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
         ...
 
     def render[F](self, renderer: Renderer[RD, F]) -> F:
-        """Transform `self.report_data` into a human-readable format.
+        """Transform `self.report_data` into a different format.
 
         :param renderer: The transformation `Callable` to apply
         :return: The result of the transformation

--- a/src/krm3/reports/generator.py
+++ b/src/krm3/reports/generator.py
@@ -1,0 +1,60 @@
+import abc
+from collections.abc import Callable
+import datetime
+
+import tablib
+
+from krm3.core.models.timesheets import TimeEntryQuerySet
+
+type Period = tuple[datetime.date, datetime.date]
+type ProcessedReportData = tablib.Databook | tablib.Dataset
+type Renderer[RD: ProcessedReportData, F] = Callable[[RD], F]
+
+
+class ReportGenerator[RD: ProcessedReportData, **P](abc.ABC):
+    def __init__(self, period: Period, *args: P.args, **kwargs: P.kwargs) -> None:
+        self.period = period
+        time_entries = self.collect(*args, **kwargs)
+        self.processed_data = self.process(time_entries)
+
+    @abc.abstractmethod
+    def collect(self, *args: P.args, **kwargs: P.kwargs) -> TimeEntryQuerySet:
+        """Collect the time entries on which the report should be generated.
+
+        :return: a Django queryset of `TimeEntry`.
+        """
+        ...
+
+    @abc.abstractmethod
+    def process(self, time_entries: TimeEntryQuerySet) -> RD:
+        """Aggregate the time entry data in order to form a tabular report.
+
+        :param time_entries: the input time entries
+        :return: a `tablib` databook or dataset with the processed data.
+        """
+        ...
+
+    def render[RD, F](self, renderer: Renderer[RD, F]) -> F:
+        """Transform `self.report_data` into a human-readable format.
+
+        :param renderer: The transformation `Callable` to apply
+        :return: The result of the transformation
+        """
+        return renderer(self.processed_data)
+
+    @property
+    def start(self) -> datetime.date:
+        return self.period[0]
+
+    @property
+    def end(self) -> datetime.date:
+        return self.period[1]
+
+    @property
+    def dates(self) -> list[datetime.date]:
+        result = []
+        current = self.start
+        while current < self.end:
+            result.append(current)
+            current += datetime.timedelta(days=1)
+        return result

--- a/src/krm3/timesheet/report/availability.py
+++ b/src/krm3/timesheet/report/availability.py
@@ -1,5 +1,5 @@
-from collections.abc import Iterable
 import datetime
+from collections.abc import Iterable
 from decimal import Decimal
 from enum import Enum
 from typing import override  # noqa: N817
@@ -7,6 +7,7 @@ from typing import override  # noqa: N817
 from dateutil.relativedelta import relativedelta
 from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
+from typing_extensions import deprecated
 
 from krm3.core.models import Project, Resource
 from krm3.timesheet.report.base import TimesheetReport
@@ -23,13 +24,11 @@ class AbsenceType(Enum):
     SPECIAL_LEAVE = _('SL')
     REST = _('R')
 
-ABSENCE_SHOW_HOURS = {
-    AbsenceType.LEAVE,
-    AbsenceType.SPECIAL_LEAVE,
-    AbsenceType.REST
-}
+
+ABSENCE_SHOW_HOURS = {AbsenceType.LEAVE, AbsenceType.SPECIAL_LEAVE, AbsenceType.REST}
 
 
+@deprecated('Use `krm3.reports.availability.AvailabilityReport` instead.')
 class AvailabilityReport(TimesheetReport):
     def __init__(
         self, from_date: datetime.date, to_date: datetime.date, user: User, project: str | None = None
@@ -78,7 +77,8 @@ class AvailabilityReport(TimesheetReport):
 
                 if te.special_leave_hours and te.special_leave_hours > 0:
                     absences[AbsenceType.SPECIAL_LEAVE] = absences.get(AbsenceType.SPECIAL_LEAVE, Decimal(0)) + Decimal(
-                        te.special_leave_hours)
+                        te.special_leave_hours
+                    )
 
                 if te.rest_hours and te.rest_hours > 0:
                     absences[AbsenceType.REST] = absences.get(AbsenceType.REST, Decimal(0)) + Decimal(te.rest_hours)
@@ -87,6 +87,7 @@ class AvailabilityReport(TimesheetReport):
         kd.absence_hours = sum(absences.values()) if absences else Decimal(0)
 
 
+@deprecated('Use `krm3.reports.availability.AvailabilityReport` instead.')
 class AvailabilityReportOnline(AvailabilityReport):
     """Online HTML report for availability/absences."""
 
@@ -115,7 +116,7 @@ class AvailabilityReportOnline(AvailabilityReport):
             resource_days = self.calendars[resource.id]
             for kd in resource_days:
                 cell_value = ''
-                #Adding absence characters to report
+                # Adding absence characters to report
                 if kd.absences:
                     parts = []
                     for absence_type in AbsenceType:
@@ -126,7 +127,7 @@ class AvailabilityReportOnline(AvailabilityReport):
                             else:
                                 parts.append(absence_type.value)
 
-                    cell_value = ', '.join(map(str,parts))
+                    cell_value = ', '.join(map(str, parts))
 
                 cell = resource_row.add_cell(cell_value)
                 cell.nwd = kd.nwd

--- a/src/krm3/utils/__init__.py
+++ b/src/krm3/utils/__init__.py
@@ -1,7 +1,7 @@
 from typing import Never
 
 
-def todo(message: str | None) -> Never:  # pragma: no cover
+def todo(message: str | None = None) -> Never:  # pragma: no cover
     """Raise an error for a stubbed out implementation.
 
     This should work like the `todo!` macro in Rust: panic (or, in

--- a/src/krm3/utils/__init__.py
+++ b/src/krm3/utils/__init__.py
@@ -1,0 +1,16 @@
+from typing import Never
+
+
+def todo(message: str | None) -> Never:  # pragma: no cover
+    """Raise an error for a stubbed out implementation.
+
+    This should work like the `todo!` macro in Rust: panic (or, in
+    Python's case, raise an exception) with an optional message
+    explaining why the implementation is not finished yet.
+
+    :param message: the optional reason
+    :raises NotImplementedError: always
+    :return: nothing
+    """
+    message = 'TODO' if message else f'TODO: {message}'
+    raise NotImplementedError(message)

--- a/src/krm3/utils/dates.py
+++ b/src/krm3/utils/dates.py
@@ -66,6 +66,9 @@ class KrmDay:
         return self.date in get_country_holidays(country_calendar_code=country_calendar_code)
 
     def is_working_day(self, country_calendar_code: str | None = None) -> bool:
+        # NOTE: this was added for forward compatibility, as there are
+        #       plans for report-friendly time entries (`DayEntry`) to
+        #       have an `is_working_day` attribute.
         return not self.is_non_working_day(country_calendar_code)
 
     def is_non_working_day(self, country_calendar_code: str | None = None) -> bool:

--- a/src/krm3/utils/dates.py
+++ b/src/krm3/utils/dates.py
@@ -9,7 +9,6 @@ from dateutil.relativedelta import MO, SU, relativedelta
 
 from krm3.config.environ import env
 
-
 type _Date = KrmDay | datetime.date | str
 type _MaybeDate = _Date | None
 
@@ -65,6 +64,9 @@ class KrmDay:
         if include_sundays_as_holiday:
             return not get_country_holidays(country_calendar_code=country_calendar_code).is_working_day(self.date)
         return self.date in get_country_holidays(country_calendar_code=country_calendar_code)
+
+    def is_working_day(self, country_calendar_code: str | None = None) -> bool:
+        return not self.is_non_working_day(country_calendar_code)
 
     def is_non_working_day(self, country_calendar_code: str | None = None) -> bool:
         return self.day_of_week_short in ['Sat', 'Sun'] or self.is_holiday(country_calendar_code=country_calendar_code)

--- a/src/krm3/web/templates/availability_report.html
+++ b/src/krm3/web/templates/availability_report.html
@@ -44,28 +44,27 @@
             </div>
         </div>
 
-        {% if report_blocks %}
+        {% if report.processed_data %}
             <div class="report-container">
                 <table class="report-table">
                     <thead>
-                    <tr class="table-header-row">
-                        {% for cell in report_blocks.0.rows.0.cells %}
-                            <td class="{% if forloop.first %}row-header{% else %}text-center workday{% endif %}">
-                                {{ cell.render|linebreaks }}
-                            </td>
-                        {% endfor %}
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% for row in report_blocks.0.rows|slice:"1:" %}
-                        <tr class="row-data">
-                            {% for cell in row.cells %}
-                                <td class="{% if forloop.first %}row-header{% else %}cell-data{% endif %} {% if cell.nwd %}non-workday{% endif %} text-center">
-                                    {{ cell.render }}
+                        <tr class="table-header-row">
+                            {% for cell in report.processed_data.headers %}
+                                <td class="{% if forloop.first %}row-header{% else %}text-center workday{% endif %}">
+                                    {{ cell | linebreaks }}
                                 </td>
                             {% endfor %}
                         </tr>
-                    {% endfor %}
+                    </thead>
+                    <tbody>
+                        {% for row in report.processed_data %}
+                            <tr class="row-data">
+                                {% for cell in row %}
+                                    <td class="{% if forloop.first %}row-header{% else %}cell-data{% endif %} {% if not cell.is_working_day %}non-workday{% endif %} text-center">
+                                        {{ cell }}
+                                    </td>
+                                {% endfor %}
+                        {% endfor %}
                     </tbody>
                 </table>
             </div>

--- a/src/krm3/web/views.py
+++ b/src/krm3/web/views.py
@@ -29,7 +29,7 @@ from django_simple_dms.models import DocumentTag
 from krm3.core.forms import ResourceForm
 from krm3.core.models import Project, Resource, Task
 from krm3.core.models.documents import ProtectedDocument as Document
-from krm3.timesheet.report.availability import AvailabilityReportOnline
+from krm3.reports.availability import AvailabilityReport
 from krm3.timesheet.report.payslip import TimesheetReportOnline
 from krm3.timesheet.report.payslip_report import TimesheetReportExport
 from krm3.timesheet.report.task import TimesheetTaskReportOnline
@@ -198,15 +198,11 @@ class AvailabilityReportView(LoginRequiredMixin, ReportMixin, TemplateView):
         context.update(ctx)
 
         selected_project = self.request.GET.get('project', '')
-        project_param = selected_project if selected_project else None
 
         projects = {'': _('All projects')} | dict(Project.objects.values_list('id', 'name'))
         context['projects'] = projects
         context['selected_project'] = selected_project
-        report_blocks = AvailabilityReportOnline(
-            ctx['start'], ctx['end'], cast('UserType', self.request.user), project_param
-        )
-        context['report_blocks'] = report_blocks.report_html()
+        context['report'] = AvailabilityReport((ctx['start'], ctx['end']), selected_project or None)
 
         return context
 

--- a/tests/unit/reports/test_availability.py
+++ b/tests/unit/reports/test_availability.py
@@ -10,7 +10,7 @@ from testutils.factories import (
     TimeEntryFactory,
 )
 
-from krm3.reports.availability import _AbsenceKind, AvailabilityReport
+from krm3.reports.availability import Absence, AbsenceKind, AvailabilityReport
 
 
 @pytest.mark.django_db
@@ -28,7 +28,7 @@ class TestComputeAbsences:
             project=None,
         )
         result = report._compute_absences([entry])
-        assert result == [(_AbsenceKind.HOLIDAY, entry.holiday_hours)]
+        assert result == [(AbsenceKind.HOLIDAY, entry.holiday_hours)]
 
     def test_sick(self):
         entry = TimeEntryFactory(
@@ -41,7 +41,7 @@ class TestComputeAbsences:
             project=None,
         )
         result = report._compute_absences([entry])
-        assert result == [(_AbsenceKind.SICK, entry.sick_hours)]
+        assert result == [(AbsenceKind.SICK, entry.sick_hours)]
 
     def test_leave(self):
         entry = TimeEntryFactory(
@@ -54,7 +54,7 @@ class TestComputeAbsences:
             project=None,
         )
         result = report._compute_absences([entry])
-        assert result == [(_AbsenceKind.LEAVE, entry.leave_hours)]
+        assert result == [(AbsenceKind.LEAVE, entry.leave_hours)]
 
     def test_special_leave(self):
         entry = TimeEntryFactory(
@@ -68,7 +68,7 @@ class TestComputeAbsences:
             project=None,
         )
         result = report._compute_absences([entry])
-        assert result == [(_AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours)]
+        assert result == [(AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours)]
 
     def test_rest(self):
         entry = TimeEntryFactory(
@@ -81,7 +81,7 @@ class TestComputeAbsences:
             project=None,
         )
         result = report._compute_absences([entry])
-        assert result == [(_AbsenceKind.REST, entry.rest_hours)]
+        assert result == [(AbsenceKind.REST, entry.rest_hours)]
 
     def test_leaves_and_rest_in_one_entry(self):
         entry = TimeEntryFactory(
@@ -98,9 +98,9 @@ class TestComputeAbsences:
         )
         result = report._compute_absences([entry])
         assert result == [
-            (_AbsenceKind.LEAVE, entry.leave_hours),
-            (_AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours),
-            (_AbsenceKind.REST, entry.rest_hours),
+            (AbsenceKind.LEAVE, entry.leave_hours),
+            (AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours),
+            (AbsenceKind.REST, entry.rest_hours),
         ]
 
     def test_no_absences(self):
@@ -161,7 +161,7 @@ class TestProcess:
         assert len(dataset) == 2
         assert set(dataset['Resource']) == {resource1.full_name, resource2.full_name}
 
-    def test_dataset_cell_contains_list_of_tuples(self):
+    def test_dataset_cell_collects_absence_data(self):
         resource = ResourceFactory()
         ContractFactory(resource=resource)
         TimeEntryFactory(
@@ -178,9 +178,9 @@ class TestProcess:
 
         row = dataset[0]
         cell = row[1]
-        assert isinstance(cell, list)
-        assert len(cell) == 1
-        assert cell[0] == (_AbsenceKind.HOLIDAY, Decimal(8))
+        assert cell.date == datetime.date(2025, 8, 1)
+        assert cell.resource == resource
+        assert cell.absences == [Absence(AbsenceKind.HOLIDAY, Decimal(8))]
 
     def test_resource_with_no_entries_has_empty_lists(self):
         resource = ResourceFactory()
@@ -193,4 +193,4 @@ class TestProcess:
 
         row = dataset[0]
         cell = row[1]
-        assert cell == []
+        assert cell.absences == []

--- a/tests/unit/reports/test_availability.py
+++ b/tests/unit/reports/test_availability.py
@@ -1,0 +1,196 @@
+import datetime
+from decimal import Decimal
+
+import pytest
+from testutils.factories import (
+    ContractFactory,
+    ResourceFactory,
+    SpecialLeaveReasonFactory,
+    TaskFactory,
+    TimeEntryFactory,
+)
+
+from krm3.reports.availability import _AbsenceKind, AvailabilityReport
+
+
+@pytest.mark.django_db
+class TestComputeAbsences:
+    """Unit tests for _compute_absences method."""
+
+    def test_holiday(self):
+        entry = TimeEntryFactory(
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            holiday_hours=8,
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == [(_AbsenceKind.HOLIDAY, entry.holiday_hours)]
+
+    def test_sick(self):
+        entry = TimeEntryFactory(
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            sick_hours=8,
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == [(_AbsenceKind.SICK, entry.sick_hours)]
+
+    def test_leave(self):
+        entry = TimeEntryFactory(
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            leave_hours=3,
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == [(_AbsenceKind.LEAVE, entry.leave_hours)]
+
+    def test_special_leave(self):
+        entry = TimeEntryFactory(
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            special_leave_hours=2,
+            special_leave_reason=SpecialLeaveReasonFactory(),
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == [(_AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours)]
+
+    def test_rest(self):
+        entry = TimeEntryFactory(
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            rest_hours=1,
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == [(_AbsenceKind.REST, entry.rest_hours)]
+
+    def test_leaves_and_rest_in_one_entry(self):
+        entry = TimeEntryFactory(
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            leave_hours=3,
+            special_leave_hours=2,
+            special_leave_reason=SpecialLeaveReasonFactory(),
+            rest_hours=1,
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == [
+            (_AbsenceKind.LEAVE, entry.leave_hours),
+            (_AbsenceKind.SPECIAL_LEAVE, entry.special_leave_hours),
+            (_AbsenceKind.REST, entry.rest_hours),
+        ]
+
+    def test_no_absences(self):
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([])
+        assert result == []
+
+    def test_day_shift_hours_does_not_create_absences(self):
+        resource = ResourceFactory()
+        task = TaskFactory(resource=resource)
+        entry = TimeEntryFactory(
+            resource=resource,
+            date=datetime.date(2025, 8, 1),
+            task=task,
+            day_shift_hours=8,
+        )
+        report = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        )
+        result = report._compute_absences([entry])
+        assert result == []
+
+
+@pytest.mark.django_db
+class TestProcess:
+    """Unit tests for process method and dataset generation."""
+
+    def test_dataset_headers(self):
+        resource = ResourceFactory()
+        ContractFactory(resource=resource)
+
+        dataset = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 4)),
+            project=None,
+        ).processed_data
+
+        assert dataset.headers[0] == 'Resource'
+        assert len(dataset.headers) == 4
+        assert 'Fri 01' in dataset.headers
+        assert 'Sat 02' in dataset.headers
+        assert 'Sun 03' in dataset.headers
+
+    def test_dataset_row_count_matches_resources(self):
+        resource1 = ResourceFactory()
+        resource2 = ResourceFactory()
+        ContractFactory(resource=resource1)
+        ContractFactory(resource=resource2)
+
+        dataset = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        ).processed_data
+
+        assert len(dataset) == 2
+        assert set(dataset['Resource']) == {resource1.full_name, resource2.full_name}
+
+    def test_dataset_cell_contains_list_of_tuples(self):
+        resource = ResourceFactory()
+        ContractFactory(resource=resource)
+        TimeEntryFactory(
+            resource=resource,
+            date=datetime.date(2025, 8, 1),
+            day_shift_hours=0,
+            holiday_hours=8,
+        )
+
+        dataset = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        ).processed_data
+
+        row = dataset[0]
+        cell = row[1]
+        assert isinstance(cell, list)
+        assert len(cell) == 1
+        assert cell[0] == (_AbsenceKind.HOLIDAY, Decimal(8))
+
+    def test_resource_with_no_entries_has_empty_lists(self):
+        resource = ResourceFactory()
+        ContractFactory(resource=resource)
+
+        dataset = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        ).processed_data
+
+        row = dataset[0]
+        cell = row[1]
+        assert cell == []

--- a/tests/unit/reports/test_availability.py
+++ b/tests/unit/reports/test_availability.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 import pytest
 from testutils.factories import (
     ContractFactory,
+    ProjectFactory,
     ResourceFactory,
     SpecialLeaveReasonFactory,
     TaskFactory,
@@ -147,7 +148,7 @@ class TestProcess:
         assert 'Sat 02' in dataset.headers
         assert 'Sun 03' in dataset.headers
 
-    def test_dataset_row_count_matches_resources(self):
+    def test_dataset_row_headers_contain_all_resources(self):
         resource1 = ResourceFactory()
         resource2 = ResourceFactory()
         ContractFactory(resource=resource1)
@@ -182,7 +183,7 @@ class TestProcess:
         assert cell.resource == resource
         assert cell.absences == [Absence(AbsenceKind.HOLIDAY, Decimal(8))]
 
-    def test_resource_with_no_entries_has_empty_lists(self):
+    def test_resource_with_no_entries_has_no_absences(self):
         resource = ResourceFactory()
         ContractFactory(resource=resource)
 
@@ -194,3 +195,142 @@ class TestProcess:
         row = dataset[0]
         cell = row[1]
         assert cell.absences == []
+
+    def test_project_filters_resources(self):
+        project = ProjectFactory()
+        resource1 = ResourceFactory()
+        resource2 = ResourceFactory()
+        ContractFactory(resource=resource1)
+        ContractFactory(resource=resource2)
+        task1 = TaskFactory(resource=resource1, project=project)
+        task2 = TaskFactory(resource=resource2)
+        TimeEntryFactory(
+            resource=resource1,
+            date=datetime.date(2025, 8, 1),
+            task=task1,
+            day_shift_hours=8,
+        )
+        TimeEntryFactory(
+            resource=resource2,
+            date=datetime.date(2025, 8, 1),
+            task=task2,
+            day_shift_hours=8,
+        )
+
+        dataset_with_project = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=project,
+        ).processed_data
+
+        dataset_without_project = AvailabilityReport(
+            period=(datetime.date(2025, 8, 1), datetime.date(2025, 8, 2)),
+            project=None,
+        ).processed_data
+
+        assert len(dataset_with_project) == 1
+        assert resource1.full_name in dataset_with_project['Resource']
+        assert len(dataset_without_project) == 2
+
+    def test_dataset_with_various_entries_across_multiple_days_and_resources(self):
+        project_a = ProjectFactory()
+        project_b = ProjectFactory()
+        resource1 = ResourceFactory()
+        resource2 = ResourceFactory()
+        ContractFactory(resource=resource1)
+        ContractFactory(resource=resource2)
+        task1 = TaskFactory(resource=resource1, project=project_a)
+        task2 = TaskFactory(resource=resource2, project=project_b)
+
+        TimeEntryFactory(
+            resource=resource1,
+            date=datetime.date(2025, 8, 4),
+            task=None,
+            day_shift_hours=0,
+            holiday_hours=8,
+        )
+        TimeEntryFactory(
+            resource=resource1,
+            date=datetime.date(2025, 8, 5),
+            task=None,
+            day_shift_hours=0,
+            leave_hours=3,
+            special_leave_hours=2,
+            rest_hours=1,
+            special_leave_reason=SpecialLeaveReasonFactory(),
+        )
+        TimeEntryFactory(
+            resource=resource1,
+            date=datetime.date(2025, 8, 6),
+            task=None,
+            day_shift_hours=0,
+            leave_hours=4,
+        )
+        TimeEntryFactory(
+            resource=resource1,
+            date=datetime.date(2025, 8, 7),
+            task=task1,
+            day_shift_hours=8,
+        )
+
+        TimeEntryFactory(
+            resource=resource2,
+            date=datetime.date(2025, 8, 4),
+            task=task2,
+            day_shift_hours=8,
+        )
+        TimeEntryFactory(
+            resource=resource2,
+            date=datetime.date(2025, 8, 5),
+            task=None,
+            day_shift_hours=0,
+            sick_hours=8,
+        )
+        TimeEntryFactory(
+            resource=resource2,
+            date=datetime.date(2025, 8, 6),
+            task=None,
+            day_shift_hours=0,
+            leave_hours=4,
+        )
+
+        dataset = AvailabilityReport(
+            period=(datetime.date(2025, 8, 4), datetime.date(2025, 8, 8)),
+            project=None,
+        ).processed_data
+
+        dataset_project_a = AvailabilityReport(
+            period=(datetime.date(2025, 8, 4), datetime.date(2025, 8, 8)),
+            project=project_a,
+        ).processed_data
+
+        dataset_project_b = AvailabilityReport(
+            period=(datetime.date(2025, 8, 4), datetime.date(2025, 8, 8)),
+            project=project_b,
+        ).processed_data
+
+        assert len(dataset) == 2
+        assert len(dataset_project_a) == 1
+        assert len(dataset_project_b) == 1
+        assert resource1.full_name in dataset['Resource']
+        assert resource2.full_name in dataset['Resource']
+        assert resource1.full_name in dataset_project_a['Resource']
+        assert resource2.full_name not in dataset_project_a['Resource']
+        assert resource2.full_name in dataset_project_b['Resource']
+        assert resource1.full_name not in dataset_project_b['Resource']
+
+        r1_row = dataset[0] if dataset[0][0] == resource1.full_name else dataset[1]
+        r2_row = dataset[1] if dataset[1][0] == resource2.full_name else dataset[0]
+
+        assert r1_row[1].absences == [Absence(AbsenceKind.HOLIDAY, Decimal(8))]
+        assert r1_row[2].absences == [
+            Absence(AbsenceKind.LEAVE, Decimal(3)),
+            Absence(AbsenceKind.SPECIAL_LEAVE, Decimal(2)),
+            Absence(AbsenceKind.REST, Decimal(1)),
+        ]
+        assert r1_row[3].absences == [Absence(AbsenceKind.LEAVE, Decimal(4))]
+        assert r1_row[4].absences == []
+
+        assert r2_row[1].absences == []
+        assert r2_row[2].absences == [Absence(AbsenceKind.SICK, Decimal(8))]
+        assert r2_row[3].absences == [Absence(AbsenceKind.LEAVE, Decimal(4))]
+        assert r2_row[4].absences == []

--- a/uv.lock
+++ b/uv.lock
@@ -1315,7 +1315,7 @@ wheels = [
 
 [[package]]
 name = "krm3"
-version = "3.5.4"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },


### PR DESCRIPTION
Report generation is now a somewhat functional-style pipeline: time entry collection, data aggregation into a `tablib` `Databook` or `Dataset`, (optional) rendering.

As a proof-of-concept, this PR contains a reimplementation of the availability report.