### PR TITLE
feat(contacts): enable contact update/delete and add tests

### DIFF
--- a/src/krm3/core/api/serializers/serializers.py
+++ b/src/krm3/core/api/serializers/serializers.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.core.validators import RegexValidator
+from django.db import transaction
 from rest_framework import serializers
 
 from krm3.core.models import (
@@ -134,41 +135,47 @@ class ContactSerializer(metaclass=ModelDefaultSerializerMetaclass):
         websites_data = validated_data.pop('websiteinfo_set', [])
         addresses_data = validated_data.pop('addressinfo_set', [])
 
-        contact = Contact.objects.create(**validated_data)
+        with transaction.atomic():
+            contact = Contact.objects.create(**validated_data)
 
-        for phone in phones_data:
-            phone_obj, _ = Phone.objects.get_or_create(number=phone['number'])
-            PhoneInfo.objects.create(contact=contact, phone=phone_obj, kind=phone.get('kind'))
-        for email in emails_data:
-            email_obj, _ = Email.objects.get_or_create(address=email['address'])
-            EmailInfo.objects.create(contact=contact, email=email_obj, kind=email.get('kind'))
-        for website in websites_data:
-            website_obj, _ = Website.objects.get_or_create(url=website['url'])
-            WebsiteInfo.objects.create(contact=contact, website=website_obj)
-        for address in addresses_data:
-            address_obj, _ = Address.objects.get_or_create(address=address['address'])
-            AddressInfo.objects.create(contact=contact, address=address_obj, kind=address.get('kind'))
+            for phone in phones_data:
+                phone_obj, _ = Phone.objects.get_or_create(number=phone['number'])
+                PhoneInfo.objects.create(contact=contact, phone=phone_obj, kind=phone.get('kind'))
+            for email in emails_data:
+                email_obj, _ = Email.objects.get_or_create(address=email['address'])
+                EmailInfo.objects.create(contact=contact, email=email_obj, kind=email.get('kind'))
+            for website in websites_data:
+                website_obj, _ = Website.objects.get_or_create(url=website['url'])
+                WebsiteInfo.objects.create(contact=contact, website=website_obj)
+            for address in addresses_data:
+                address_obj, _ = Address.objects.get_or_create(address=address['address'])
+                AddressInfo.objects.create(contact=contact, address=address_obj, kind=address.get('kind'))
 
         return contact
 
     def update(self, instance: Contact, validated_data: dict[str, Any]) -> Contact:
-        phones_data = validated_data.pop('phoneinfo_set', [])
-        emails_data = validated_data.pop('emailinfo_set', [])
-        websites_data = validated_data.pop('websiteinfo_set', [])
-        addresses_data = validated_data.pop('addressinfo_set', [])
+        phones_data = validated_data.pop('phoneinfo_set', None)
+        emails_data = validated_data.pop('emailinfo_set', None)
+        websites_data = validated_data.pop('websiteinfo_set', None)
+        addresses_data = validated_data.pop('addressinfo_set', None)
 
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-        instance.save()
+        with transaction.atomic():
+            for attr, value in validated_data.items():
+                setattr(instance, attr, value)
+            instance.save()
 
-        self._update_related_phones(instance, phones_data)
-        self._update_related_emails(instance, emails_data)
-        self._update_related_websites(instance, websites_data)
-        self._update_related_addresses(instance, addresses_data)
+            if phones_data is not None:
+                self._update_related_phones(instance, phones_data)
+            if emails_data is not None:
+                self._update_related_emails(instance, emails_data)
+            if websites_data is not None:
+                self._update_related_websites(instance, websites_data)
+            if addresses_data is not None:
+                self._update_related_addresses(instance, addresses_data)
 
         return instance
 
-    def _update_related_phones(self, contact, phones_data):
+    def _update_related_phones(self, contact: Contact, phones_data: list[dict[str, Any]]) -> None:
         existing = {phone_info.phone.number: phone_info for phone_info in contact.phoneinfo_set.all()}
         submitted = {phone['number']: phone for phone in phones_data}
 
@@ -184,7 +191,7 @@ class ContactSerializer(metaclass=ModelDefaultSerializerMetaclass):
                 phone_obj, _ = Phone.objects.get_or_create(number=number)
                 PhoneInfo.objects.create(contact=contact, phone=phone_obj, kind=phone.get('kind'))
 
-    def _update_related_emails(self, contact, emails_data):
+    def _update_related_emails(self, contact: Contact, emails_data: list[dict[str, Any]]) -> None:
         existing = {email_info.email.address: email_info for email_info in contact.emailinfo_set.all()}
         submitted = {email['address']: email for email in emails_data}
 
@@ -200,7 +207,7 @@ class ContactSerializer(metaclass=ModelDefaultSerializerMetaclass):
                 email_obj, _ = Email.objects.get_or_create(address=address)
                 EmailInfo.objects.create(contact=contact, email=email_obj, kind=email.get('kind'))
 
-    def _update_related_websites(self, contact, websites_data):
+    def _update_related_websites(self, contact: Contact, websites_data: list[dict[str, Any]]) -> None:
         existing = {website_info.website.url: website_info for website_info in contact.websiteinfo_set.all()}
         submitted = {website['url']: website for website in websites_data}
 
@@ -208,14 +215,14 @@ class ContactSerializer(metaclass=ModelDefaultSerializerMetaclass):
             if url not in submitted:
                 website_info.delete()
 
-        for url, website in submitted.items():
+        for url in submitted:
             if url in existing:
                 pass
             else:
                 website_obj, _ = Website.objects.get_or_create(url=url)
                 WebsiteInfo.objects.create(contact=contact, website=website_obj)
 
-    def _update_related_addresses(self, contact, addresses_data):
+    def _update_related_addresses(self, contact: Contact, addresses_data: list[dict[str, Any]]) -> None:
         existing = {address_info.address.address: address_info for address_info in contact.addressinfo_set.all()}
         submitted = {address['address']: address for address in addresses_data}
 

--- a/src/krm3/core/api/serializers/serializers.py
+++ b/src/krm3/core/api/serializers/serializers.py
@@ -150,3 +150,83 @@ class ContactSerializer(metaclass=ModelDefaultSerializerMetaclass):
             AddressInfo.objects.create(contact=contact, address=address_obj, kind=address.get('kind'))
 
         return contact
+
+    def update(self, instance: Contact, validated_data: dict[str, Any]) -> Contact:
+        phones_data = validated_data.pop('phoneinfo_set', [])
+        emails_data = validated_data.pop('emailinfo_set', [])
+        websites_data = validated_data.pop('websiteinfo_set', [])
+        addresses_data = validated_data.pop('addressinfo_set', [])
+
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+
+        self._update_related_phones(instance, phones_data)
+        self._update_related_emails(instance, emails_data)
+        self._update_related_websites(instance, websites_data)
+        self._update_related_addresses(instance, addresses_data)
+
+        return instance
+
+    def _update_related_phones(self, contact, phones_data):
+        existing = {phone_info.phone.number: phone_info for phone_info in contact.phoneinfo_set.all()}
+        submitted = {phone['number']: phone for phone in phones_data}
+
+        for number, phone_info in existing.items():
+            if number not in submitted:
+                phone_info.delete()
+
+        for number, phone in submitted.items():
+            if number in existing:
+                existing[number].kind = phone.get('kind')
+                existing[number].save()
+            else:
+                phone_obj, _ = Phone.objects.get_or_create(number=number)
+                PhoneInfo.objects.create(contact=contact, phone=phone_obj, kind=phone.get('kind'))
+
+    def _update_related_emails(self, contact, emails_data):
+        existing = {email_info.email.address: email_info for email_info in contact.emailinfo_set.all()}
+        submitted = {email['address']: email for email in emails_data}
+
+        for address, email_info in existing.items():
+            if address not in submitted:
+                email_info.delete()
+
+        for address, email in submitted.items():
+            if address in existing:
+                existing[address].kind = email.get('kind')
+                existing[address].save()
+            else:
+                email_obj, _ = Email.objects.get_or_create(address=address)
+                EmailInfo.objects.create(contact=contact, email=email_obj, kind=email.get('kind'))
+
+    def _update_related_websites(self, contact, websites_data):
+        existing = {website_info.website.url: website_info for website_info in contact.websiteinfo_set.all()}
+        submitted = {website['url']: website for website in websites_data}
+
+        for url, website_info in existing.items():
+            if url not in submitted:
+                website_info.delete()
+
+        for url, website in submitted.items():
+            if url in existing:
+                pass
+            else:
+                website_obj, _ = Website.objects.get_or_create(url=url)
+                WebsiteInfo.objects.create(contact=contact, website=website_obj)
+
+    def _update_related_addresses(self, contact, addresses_data):
+        existing = {address_info.address.address: address_info for address_info in contact.addressinfo_set.all()}
+        submitted = {address['address']: address for address in addresses_data}
+
+        for address_str, address_info in existing.items():
+            if address_str not in submitted:
+                address_info.delete()
+
+        for address_str, address in submitted.items():
+            if address_str in existing:
+                existing[address_str].kind = address.get('kind')
+                existing[address_str].save()
+            else:
+                address_obj, _ = Address.objects.get_or_create(address=address_str)
+                AddressInfo.objects.create(contact=contact, address=address_obj, kind=address.get('kind'))

--- a/src/krm3/core/api/views.py
+++ b/src/krm3/core/api/views.py
@@ -319,7 +319,7 @@ class ContactAPIViewSet(ModelViewSet):
     pagination_class = DefaultPagination
     filter_backends = [filters.SearchFilter]
     search_fields = ['first_name', 'last_name', 'company__name']
-    http_method_names = ['get', 'post']
+    http_method_names = ['get', 'post', 'put', 'patch', 'delete']
 
     def get_queryset(self) -> QuerySet[Contact]:
         if self.request.user.is_superuser or self.request.user.has_perm('core.view_contact'):
@@ -334,6 +334,12 @@ class ContactAPIViewSet(ModelViewSet):
 
     def perform_create(self, serializer: 'ContactSerializer') -> None:
         serializer.save(user=self.request.user)
+
+    def perform_update(self, serializer: 'ContactSerializer') -> None:
+        serializer.save()
+
+    def perform_destroy(self, instance: Contact) -> None:
+        instance.delete()
 
 
 class TitleChoicesViewSet(ViewSet):

--- a/tests/unit/web/test_contacts.py
+++ b/tests/unit/web/test_contacts.py
@@ -243,3 +243,62 @@ def test_delete_contact(admin_client):
     response = admin_client.delete(reverse('core-api:contacts-detail', kwargs={'pk': contact.pk}))
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert not Contact.objects.filter(pk=contact.pk).exists()
+
+
+def test_patch_contact_preserves_related_data(admin_client):
+    contact = ContactFactory(phones=1, emails=1, addresses=1, websites=1, is_active=True)
+    response = admin_client.patch(
+        reverse('core-api:contacts-detail', kwargs={'pk': contact.pk}),
+        data={'isActive': False},
+        content_type='application/json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()['isActive'] is False
+    contact.refresh_from_db()
+    assert contact.is_active is False
+    assert contact.phones.count() == 1
+    assert contact.emails.count() == 1
+    assert contact.addresses.count() == 1
+    assert contact.websites.count() == 1
+
+
+def test_patch_contact_updates_related_data(admin_client):
+    contact = ContactFactory(phones=2, emails=2, addresses=2, websites=2)
+
+    phone = contact.phones.first()
+    email = contact.emails.first()
+    address = contact.addresses.first()
+    website = contact.websites.first()
+
+    response = admin_client.patch(
+        reverse('core-api:contacts-detail', kwargs={'pk': contact.pk}),
+        data={
+            'phones': [
+                {'number': phone.number, 'kind': 'updated'},
+                {'number': '+000000000', 'kind': 'new'},
+            ],
+            'emails': [
+                {'address': email.address, 'kind': 'updated'},
+                {'address': 'new@example.com', 'kind': 'new'},
+            ],
+            'addresses': [
+                {'address': address.address, 'kind': 'updated'},
+                {'address': 'New Address', 'kind': 'new'},
+            ],
+            'websites': [
+                {'url': website.url},
+                {'url': 'https://new.example.com'},
+            ],
+        },
+        content_type='application/json',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+
+    assert data['firstName'] == contact.first_name
+
+    assert len(data['phones']) == 2
+    assert len(data['emails']) == 2
+    assert len(data['addresses']) == 2
+    assert len(data['websites']) == 2

--- a/tests/unit/web/test_contacts.py
+++ b/tests/unit/web/test_contacts.py
@@ -210,3 +210,36 @@ def test_titles_endpoint_returns_all_choices(admin_client):
     titles = response.json()
     expected = [{'value': choice.value, 'label': choice.label} for choice in Contact.TitleChoices]
     assert titles == expected
+
+
+def test_patch_contact_deactivates(admin_client):
+    contact = ContactFactory(is_active=True)
+    response = admin_client.patch(
+        reverse('core-api:contacts-detail', kwargs={'pk': contact.pk}),
+        data={'isActive': False},
+        content_type='application/json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()['isActive'] is False
+    contact.refresh_from_db()
+    assert contact.is_active is False
+
+
+def test_patch_contact_activates(admin_client):
+    contact = ContactFactory(is_active=False)
+    response = admin_client.patch(
+        reverse('core-api:contacts-detail', kwargs={'pk': contact.pk}),
+        data={'isActive': True},
+        content_type='application/json',
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()['isActive'] is True
+    contact.refresh_from_db()
+    assert contact.is_active is True
+
+
+def test_delete_contact(admin_client):
+    contact = ContactFactory()
+    response = admin_client.delete(reverse('core-api:contacts-detail', kwargs={'pk': contact.pk}))
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert not Contact.objects.filter(pk=contact.pk).exists()


### PR DESCRIPTION
**Description:**

This PR enables full contact lifecycle support on the `ContactAPIViewSet`.

### What's changed
- Enabled `PATCH` and `DELETE` methods on `ContactAPIViewSet`.
- Overrode `ContactSerializer.update()` to handle nested related data:
  - phones
  - emails
  - websites
  - addresses
- The update logic creates new related entries, updates existing ones, and removes entries that are no longer provided.
- Added tests for:
  - `PATCH` deactivating a contact
  - `PATCH` activating a contact
  - `DELETE` removing a contact
