### PR TITLE
fix(admin): prevent crashes when searching with empty date range filter

### DIFF
--- a/src/krm3/daterange.py
+++ b/src/krm3/daterange.py
@@ -1,71 +1,81 @@
-import datetime
-import typing
-from django.db.backends.postgresql.psycopg_any import DateRange
+from __future__ import annotations
+
+from typing import override, TYPE_CHECKING
+
+from django.db.backends.postgresql.psycopg_any import DateRange  # pyright: ignore
 from rangefilter.filters import DateRangeFilter
 
 from krm3.utils.dates import KrmDay
 
-if typing.TYPE_CHECKING:
-    from django.db.models import QuerySet
+if TYPE_CHECKING:
+    import datetime
+    from django.db.models import Model, QuerySet
     from django.http import HttpRequest
 
 
 class DateRangeFilterBase(DateRangeFilter):
     """Base class for DateRangeFilter."""
 
-    method: str = None
+    method: str = ''
 
-    def __init__(self, field, request, params, model, model_admin, field_path) -> None:  # noqa: ANN001, PLR0913
+    @override
+    def __init__(self, field, request, params, model: type[Model], model_admin, field_path) -> None:  # noqa: ANN001, PLR0913
         super().__init__(field, request, params, model, model_admin, field_path)
-        self.title = f'{self.field_path} ({self.method})'
+        self.title = f'{self.field_path} ({self.method or "none"})'
 
-    def queryset(self, request: 'HttpRequest', queryset: 'QuerySet') -> 'QuerySet':
-        """Return queryset."""
-        if self.form.is_valid():
-            validated_data = dict(self.form.cleaned_data.items())
-            if validated_data:
-                lower, upper = self._make_query_filter(request, validated_data)
-                lower = lower.strftime('%Y-%m-%d')
-                upper = (KrmDay(upper) + 1).date.strftime('%Y-%m-%d')
-                return queryset.filter(**{f'{self.field_path}__{self.method}': DateRange(lower, upper)})
-        return queryset
+    @override
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        if not self.form.is_valid():
+            return queryset
 
-    def _make_query_filter(self, request: 'HttpRequest', validated_data: dict) -> tuple[datetime.date, datetime.date]:
-        date_value_lower = validated_data.get(self.lookup_kwarg_gte, None)
-        date_value_upper = validated_data.get(self.lookup_kwarg_lte, None)
+        if not self.form.cleaned_data:
+            return queryset
 
-        if date_value_lower or date_value_upper:
-            if date_value_upper is None:
-                date_value_upper = date_value_lower
-            elif date_value_lower is None:
-                date_value_lower = date_value_upper
+        lower, upper = self._make_query_filter()
+        if lower is not None:
+            lower = lower.strftime('%Y-%m-%d')
+        if upper is not None:
+            upper = (KrmDay(upper) + 1).date.strftime('%Y-%m-%d')
+        return queryset.filter(**{f'{self.field_path}__{self.method}': DateRange(lower, upper)})
+
+    def _make_query_filter(self) -> tuple[datetime.date, datetime.date] | tuple[None, None]:
+        date_value_lower = self.form.cleaned_data.get(self.lookup_kwarg_gte)
+        date_value_upper = self.form.cleaned_data.get(self.lookup_kwarg_lte)
 
         return date_value_lower, date_value_upper
 
 
 class DateRangeOverlapFilter(DateRangeFilterBase):
-    method : str = 'overlap'
+    method: str = 'overlap'
+
 
 class DateRangeContainedByFilter(DateRangeFilterBase):
-    method : str = 'contained_by'
+    method: str = 'contained_by'
+
 
 class DateRangeContainsFilter(DateRangeFilterBase):
-    method : str = 'contains'
+    method: str = 'contains'
+
 
 class DateRangeFullyLtFilter(DateRangeFilterBase):
-    method : str = 'fully_lt'
+    method: str = 'fully_lt'
+
 
 class DateRangeFullyGtFilter(DateRangeFilterBase):
-    method : str = 'fully_gt'
+    method: str = 'fully_gt'
+
 
 class DateRangeNotLtFilter(DateRangeFilterBase):
-    method : str = 'not_lt'
+    method: str = 'not_lt'
+
 
 class DateRangeNotGtFilter(DateRangeFilterBase):
-    method : str = 'not_gt'
+    method: str = 'not_gt'
+
 
 class DateRangeAdjacentToFilter(DateRangeFilterBase):
-    method : str = 'adjacent_to'
+    method: str = 'adjacent_to'
+
 
 __all__ = [
     'DateRangeOverlapFilter',

--- a/src/krm3/daterange.py
+++ b/src/krm3/daterange.py
@@ -8,13 +8,12 @@ from rangefilter.filters import DateRangeFilter
 from krm3.utils.dates import KrmDay
 
 if TYPE_CHECKING:
-    import datetime
     from django.db.models import Model, QuerySet
     from django.http import HttpRequest
 
 
 class DateRangeFilterBase(DateRangeFilter):
-    """Base class for DateRangeFilter."""
+    """Base class for custom filters based on date ranges."""
 
     method: str = ''
 
@@ -31,18 +30,15 @@ class DateRangeFilterBase(DateRangeFilter):
         if not self.form.cleaned_data:
             return queryset
 
-        lower, upper = self._make_query_filter()
+        lower = self.form.cleaned_data.get(self.lookup_kwarg_gte)
         if lower is not None:
             lower = lower.strftime('%Y-%m-%d')
+
+        upper = self.form.cleaned_data.get(self.lookup_kwarg_lte)
         if upper is not None:
             upper = (KrmDay(upper) + 1).date.strftime('%Y-%m-%d')
+
         return queryset.filter(**{f'{self.field_path}__{self.method}': DateRange(lower, upper)})
-
-    def _make_query_filter(self) -> tuple[datetime.date, datetime.date] | tuple[None, None]:
-        date_value_lower = self.form.cleaned_data.get(self.lookup_kwarg_gte)
-        date_value_upper = self.form.cleaned_data.get(self.lookup_kwarg_lte)
-
-        return date_value_lower, date_value_upper
 
 
 class DateRangeOverlapFilter(DateRangeFilterBase):

--- a/tests/integration/test_admin_panel.py
+++ b/tests/integration/test_admin_panel.py
@@ -1,28 +1,28 @@
-import json
-import time
 import datetime
+import json
 import os
 import tempfile
-
-from freezegun import freeze_time
-from constance.test import override_config
-from krm3.core.models.missions import Mission
-import pytest
-
+import time
 import typing
 
+import pytest
+from constance.test import override_config
+from django.contrib.auth.models import Permission
+from freezegun import freeze_time
 from selenium.webdriver.common.by import By
 from testutils.factories import (
-    TaskFactory,
-    TimeEntryFactory,
+    ContractFactory,
+    ExpenseFactory,
+    MissionFactory,
+    ReimbursementFactory,
     ResourceFactory,
     SpecialLeaveReasonFactory,
-    MissionFactory,
-    ExpenseFactory,
-    ReimbursementFactory,
-    ContractFactory,
+    TaskFactory,
+    TimeEntryFactory,
+    TimesheetSubmissionFactory,
 )
-from django.contrib.auth.models import Permission
+
+from krm3.core.models.missions import Mission
 
 if typing.TYPE_CHECKING:
     from testutils.selenium import AppTestBrowser
@@ -336,6 +336,7 @@ def test_admin_submit_mission(browser: 'AppTestBrowser', admin_user_with_plain_p
 def test_expense_list_displays_image_link(browser: 'AppTestBrowser', admin_user_with_plain_password):
     """Test that the expense list displays image link when image exists and '-' when not."""
     from unittest.mock import MagicMock
+
     from django.core.files import File
 
     mission = MissionFactory(number=1, status=Mission.MissionStatus.SUBMITTED, to_date=datetime.date.today())
@@ -429,7 +430,7 @@ def test_admin_missions_create_reibursments_get_preview(browser: 'AppTestBrowser
         mission=mission,
         amount_reimbursement=100,
     )
-    expense.image = "fake_image.jpg"
+    expense.image = 'fake_image.jpg'
     expense.save()
     browser.admin_user = admin_user_with_plain_password
     browser.login()
@@ -446,7 +447,6 @@ def test_admin_missions_create_reibursments_get_preview(browser: 'AppTestBrowser
     # the rembursment is correctly created
     expense.refresh_from_db()
     assert expense.reimbursement is not None
-
 
 
 def test_contract_document_validation_pdf_only(browser: 'AppTestBrowser', admin_user_with_plain_password):
@@ -495,3 +495,57 @@ def test_contract_document_validation_pdf_only(browser: 'AppTestBrowser', admin_
 
     finally:
         os.unlink(tmp_file_path)
+
+
+@pytest.fixture
+def submissions():
+    return {
+        'january': TimesheetSubmissionFactory(
+            period=(datetime.date(2026, 1, 1), datetime.date(2026, 2, 1)),
+            closed=True,
+        ),
+        'february': TimesheetSubmissionFactory(
+            period=(datetime.date(2026, 2, 1), datetime.date(2026, 3, 1)),
+            closed=True,
+        ),
+        'march': TimesheetSubmissionFactory(
+            period=(datetime.date(2026, 3, 1), datetime.date(2026, 4, 1)),
+            closed=True,
+        ),
+        'mid_month': TimesheetSubmissionFactory(
+            period=(datetime.date(2026, 3, 15), datetime.date(2026, 4, 16)),
+            resource=ResourceFactory(),
+            closed=True,
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ('lower_bound', 'upper_bound', 'expected_submissions'),
+    [
+        pytest.param('2026-01-01', '2026-02-01', 2, id='lower_upper_bound'),
+        pytest.param('2026-01-02', '', 4, id='lower_bound'),
+        pytest.param('', '2026-03-01', 3, id='upper_bound'),
+        pytest.param('2025-01-01', '2025-02-01', 0, id='out_of_bound'),
+        pytest.param('', '', 4, id='no_bound'),
+        pytest.param('random', 'string', 4, id='wrong_date'),
+    ],
+)
+def test_timesheet_submission_date_range_filter(
+    lower_bound,
+    upper_bound,
+    expected_submissions,
+    browser: 'AppTestBrowser',
+    admin_user_with_plain_password,
+    submissions,
+):
+    browser.admin_user = admin_user_with_plain_password
+    browser.login()
+    browser.click('//a[@href="/admin/core/timesheetsubmission/"]')
+    lower_bound_period = browser.find_element(By.XPATH, '//input[@name="period__range__gte"]')
+    upper_bound_period = browser.find_element(By.XPATH, '//input[@name="period__range__lte"]')
+    lower_bound_period.send_keys(lower_bound)
+    upper_bound_period.send_keys(upper_bound)
+    browser.click('//input[@type="submit" and @value="Search"]')
+    table_rows = browser.find_elements(By.XPATH, '//table[@id="result_list"]/tbody/tr')
+    assert len(table_rows) == expected_submissions


### PR DESCRIPTION
This also addresses a UX concern where picking only one of the from/to dates of the range filter would only search for the specified date instead of using an unbounded interval.