### PR TITLE
Fix update_rates skipping conversion for same-day expenses; remove dead future-day guard

### DIFF
--- a/src/krm3/missions/actions.py
+++ b/src/krm3/missions/actions.py
@@ -3,17 +3,18 @@ import typing
 from django.contrib import admin, messages
 from django.template.response import TemplateResponse
 
+from krm3.core.models import Mission
 from krm3.missions.facilities import ReimbursementFacility
 from krm3.missions.forms import MissionsReimbursementForm
-from krm3.core.models import Mission
 from krm3.sentry import capture_exception
 from krm3.utils.rates import update_rates
 
 if typing.TYPE_CHECKING:
+    from django.contrib.admin.options import ModelAdmin
     from django.db.models import QuerySet
     from django.http import HttpRequest, HttpResponse
+
     from krm3.core.models import Expense
-    from django.contrib.admin.options import ModelAdmin
 
 
 @admin.action(description='Recalculate reimbursement')
@@ -21,6 +22,7 @@ def recalculate_reimbursement(modeladmin: 'ModelAdmin', request: 'HttpRequest', 
     for expense in queryset.filter(reimbursement=None).all():
         expense.amount_reimbursement = expense.get_reimbursement_amount()
         expense.save()
+
 
 @admin.action(description='Reset reimbursement')
 def reset_reimbursement(modeladmin: 'ModelAdmin', request: 'HttpRequest', queryset: 'QuerySet[Expense]') -> None:
@@ -69,7 +71,7 @@ def get_rates(
     expenses = queryset.filter(amount_base__isnull=True)
     ret = expenses.count()
     qs = expenses.all()
-    update_rates(request, qs)
+    update_rates(qs)
     msg = f'Converted {ret} amounts'
     if silent:
         return msg

--- a/src/krm3/utils/rates.py
+++ b/src/krm3/utils/rates.py
@@ -1,40 +1,26 @@
-from datetime import datetime
+import typing
 
 from pyoxr import OXRError
 
 from krm3.currencies.models import Rate
 from krm3.missions.exceptions import RateConversionError
 
-import typing
-
-from krm3.utils.tools import message_add_once
-
 if typing.TYPE_CHECKING:
-    from krm3.core.models import Expense
     from django.db.models import QuerySet
-    from django.http import HttpRequest
+
+    from krm3.core.models import Expense
 
 
-def update_rates(request: 'HttpRequest', qs: 'QuerySet[Expense]') -> None:
+def update_rates(qs: 'QuerySet[Expense]') -> None:
     rates_dict = {}
-    future_days = []
     try:
         for expense in qs:
-            if expense.day in rates_dict:
-                rate = rates_dict[expense.day]
-            elif expense.day > datetime.today().date():
-                future_days.append(expense.day)
-            else:
-                rate = rates_dict.setdefault(expense.day, Rate.for_date(expense.day))
-                expense.amount_base = rate.convert(expense.amount_currency, from_currency=expense.currency)
-                if expense.amount_reimbursement is None:
-                    expense.amount_reimbursement = expense.get_reimbursement_amount()
-                expense.save()
+            if expense.day not in rates_dict:
+                rates_dict[expense.day] = Rate.for_date(expense.day)
+            rate = rates_dict[expense.day]
+            expense.amount_base = rate.convert(expense.amount_currency, from_currency=expense.currency)
+            if expense.amount_reimbursement is None:
+                expense.amount_reimbursement = expense.get_reimbursement_amount()
+            expense.save()
     except OXRError as e:
         raise RateConversionError(e)
-    if future_days:
-        message = (
-            f'It was impossible to apply rate conversions for the following future days:'
-            f' {", ".join(map(str, set(future_days)))}'
-        )
-        message_add_once('warning', request, message)

--- a/tests/unit/utils/test_rates.py
+++ b/tests/unit/utils/test_rates.py
@@ -1,0 +1,38 @@
+from datetime import date
+from decimal import Decimal
+
+import responses
+from testutils.factories import CurrencyFactory, ExpenseFactory
+
+from krm3.core.models import Expense
+from krm3.utils.rates import update_rates
+
+
+@responses.activate
+def test_update_rates_converts_all_same_day_expenses(mock_rate_provider):
+    """Different currencies all convert to the base currency at the same rate."""
+    day = date(2026, 1, 1)
+    mock_rate_provider(day, 'EUR,GBP,USD', {'EUR': 0.2, 'GBP': 2, 'USD': 1})
+
+    expense1 = ExpenseFactory(
+        day=day, amount_currency=100, amount_base=None, amount_reimbursement=None, currency=CurrencyFactory(iso3='GBP')
+    )
+    expense2 = ExpenseFactory(
+        day=day, amount_currency=100, amount_base=None, amount_reimbursement=None, currency=CurrencyFactory(iso3='EUR')
+    )
+    expense3 = ExpenseFactory(
+        day=day, amount_currency=100, amount_base=None, amount_reimbursement=None, currency=CurrencyFactory(iso3='USD')
+    )
+
+    update_rates(Expense.objects.filter(id__in=[expense1.id, expense2.id, expense3.id]))
+
+    expense1.refresh_from_db()
+    expense2.refresh_from_db()
+    expense3.refresh_from_db()
+
+    assert expense1.amount_base == Decimal(10)
+    assert expense2.amount_base == Decimal(100)
+    assert expense3.amount_base == Decimal(20)
+    assert expense1.amount_reimbursement is not None
+    assert expense2.amount_reimbursement is not None
+    assert expense3.amount_reimbursement is not None


### PR DESCRIPTION
The `update_rates` function had a control-flow bug where only the first expense per day was converted — subsequent same-day expenses hit the `if expense.day in rates_dict` branch which retrieved the cached rate but fell through without calling `rate.convert()` or `expense.save()`.